### PR TITLE
Remove redundant imports in evaluate_prophet_model

### DIFF
--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -1627,12 +1627,7 @@ def export_prophet_forecast(model, forecast, df, output_dir):
 
 
 def evaluate_prophet_model(model, prophet_df):
-    """
-    Cross‑validate the Prophet model and report MAE, RMSE, and MAPE.
-    """
-    import logging
-    from prophet.diagnostics import cross_validation, performance_metrics
-    import numpy as np
+    """Cross‑validate the Prophet model and report MAE, RMSE, and MAPE."""
 
     logger = logging.getLogger(__name__)
     logger.info(


### PR DESCRIPTION
## Summary
- drop `logging`, `cross_validation`, `performance_metrics`, and `numpy` imports inside `evaluate_prophet_model`
- rely on top-level imports instead

## Testing
- `python -m py_compile prophet_analysis.py`
