### PR TITLE
Add cross-validation option and expand tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,13 @@ python prophet_analysis.py calls.csv visitors.csv queries.csv output_dir
 - `--handle-outliers METHOD` – handle detected outliers using `winsorize`, `median_replace` or `interpolate`.
 - `--use-transformation BOOL` – apply a log transformation to the target before modeling (`true` or `false`).
 - `--skip-feature-importance` – skip the feature importance analysis step.
+- `--cross-validate` – run full Prophet cross-validation after training.
 
 For example:
 
 ```bash
 python prophet_analysis.py calls.csv visitors.csv queries.csv prophet_results \
-    --handle-outliers winsorize --use-transformation false
+    --handle-outliers winsorize --use-transformation false --cross-validate
 ```
 
 The results, including forecasts and plots, will be saved in the specified output directory.


### PR DESCRIPTION
## Summary
- expand Prophet hyperparameter search grid
- add `--cross-validate` argument to optionally run full Prophet cross-validation
- save cross-validation metrics when enabled
- document new option in README

## Testing
- `python -m py_compile prophet_analysis.py`