### PR TITLE
Add naive baseline to forecast Excel export

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,5 @@ python prophet_analysis.py calls.csv visitors.csv queries.csv prophet_results \
 
 The results, including forecasts and plots, will be saved in the specified output directory.
 The exported Excel report now includes predictions for the previous 14 business days
-along with a forecast for the next business day.
+along with a forecast for the next business day. A naive baseline forecast for the
+same 14-day window and corresponding MAE, RMSE, and MAPE metrics are also included.

--- a/naive_forecast.py
+++ b/naive_forecast.py
@@ -1,0 +1,56 @@
+"""Naive forecast for call volumes using previous day's value.
+
+This script reads `calls.csv` and produces predictions for the last
+14 days using the value from the prior day as the prediction. It also
+reports MAE, RMSE and MAPE to compare predictions to actual values.
+"""
+import csv
+from datetime import datetime
+from math import sqrt
+
+# Load call data
+rows = []
+with open('calls.csv') as f:
+    reader = csv.reader(f)
+    for row in reader:
+        if not row:
+            continue
+        date_str, value_str = row
+        try:
+            date = datetime.strptime(date_str.strip(), '%m/%d/%Y')
+        except ValueError:
+            # skip header or malformed lines
+            continue
+        rows.append((date.strftime('%Y-%m-%d'), float(value_str)))
+
+# Ensure data is sorted by date
+rows.sort(key=lambda x: x[0])
+
+# Need one extra day for the first prediction
+recent = rows[-15:]
+
+preds = []
+acts = []
+dates = []
+for i in range(1, len(recent)):
+    pred = recent[i - 1][1]
+    actual = recent[i][1]
+    preds.append(pred)
+    acts.append(actual)
+    dates.append(recent[i][0])
+
+# Compute metrics
+n = len(preds)
+mae = sum(abs(a - p) for a, p in zip(acts, preds)) / n
+rmse = sqrt(sum((a - p) ** 2 for a, p in zip(acts, preds)) / n)
+mape = (
+    sum(abs(a - p) / a for a, p in zip(acts, preds) if a != 0) / n * 100
+)
+
+print("date,predicted,actual")
+for d, p, a in zip(dates, preds, acts):
+    print(f"{d},{p},{a}")
+
+print(f"MAE,{mae:.2f}")
+print(f"RMSE,{rmse:.2f}")
+print(f"MAPE,{mape:.2f}%")

--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -1474,8 +1474,56 @@ def analyze_press_release_impact_prophet(forecast, output_dir):
     
     # Save press release effects
     press_releases.to_csv(output_dir / "press_release_effects.csv", index=False)
-    
+
     return press_releases
+
+
+def compute_naive_baseline(df: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Generate a naive forecast for the last 14 days and metrics.
+
+    The naive approach simply uses the previous day's call count as the
+    prediction for the current day. This mirrors the lightweight logic in
+    ``naive_forecast.py`` and avoids the need for additional packages.
+
+    Parameters
+    ----------
+    df : DataFrame
+        Source data with a ``call_count`` column and a DatetimeIndex.
+
+    Returns
+    -------
+    Tuple of ``(forecast_df, metrics_df)`` where ``forecast_df`` contains the
+    date, predicted call count, actual call count and error columns. The
+    ``metrics_df`` provides MAE, RMSE and MAPE aggregated over the period.
+    """
+
+    df_sorted = df.sort_index()
+    recent = df_sorted["call_count"].iloc[-15:]
+    preds = recent.shift(1).dropna()
+    actual = recent.iloc[1:]
+    dates = actual.index
+
+    result = pd.DataFrame({
+        "date": dates,
+        "predicted": preds.values,
+        "actual": actual.values,
+    })
+    result["error"] = result["actual"] - result["predicted"]
+    result["abs_error"] = result["error"].abs()
+    result["pct_error"] = (
+        result["abs_error"] / result["actual"].replace(0, np.nan)
+    ) * 100
+
+    mae = result["abs_error"].mean()
+    rmse = np.sqrt((result["error"] ** 2).mean())
+    mape = result["pct_error"].mean()
+
+    metrics = pd.DataFrame({
+        "metric": ["MAE", "RMSE", "MAPE"],
+        "value": [mae, rmse, mape],
+    })
+
+    return result, metrics
 
 
 def export_prophet_forecast(model, forecast, df, output_dir):
@@ -1571,6 +1619,22 @@ def export_prophet_forecast(model, forecast, df, output_dir):
             'pct_error': recent_forecast['pct_error']
         })
         recent_performance.to_excel(writer, sheet_name='Recent 14-Day Performance', index=False)
+
+        # Metrics for Prophet predictions
+        prophet_metrics = pd.DataFrame({
+            'metric': ['MAE', 'RMSE', 'MAPE'],
+            'value': [
+                recent_performance['abs_error'].mean(),
+                np.sqrt((recent_performance['error'] ** 2).mean()),
+                recent_performance['pct_error'].mean()
+            ]
+        })
+        prophet_metrics.to_excel(writer, sheet_name='Prophet Metrics', index=False)
+
+        # Naive baseline forecast and metrics
+        naive_df, naive_metrics = compute_naive_baseline(df)
+        naive_df.to_excel(writer, sheet_name='Naive 14-Day Forecast', index=False)
+        naive_metrics.to_excel(writer, sheet_name='Naive Metrics', index=False)
         
         # Next day forecast
         next_day_df.to_excel(writer, sheet_name='Next Day Forecast', index=False)


### PR DESCRIPTION
## Summary
- compute naive forecast for last 14 days inside `prophet_analysis.py`
- export prophet metrics and naive baseline metrics to Excel
- document naive baseline sheet in README

## Testing
- `python3 -m py_compile naive_forecast.py prophet_analysis.py`
- `python3 naive_forecast.py`