### PR TITLE
Implement business-day preprocessing and updated pipeline

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,10 +1,10 @@
 model:
   seasonality_mode: multiplicative
   additive_terms: ['event_dummies']
-  seasonality_prior_scale: 10
+  seasonality_prior_scale: 0.05
   holidays_prior_scale: 20
   changepoint_prior_scale: 0.5
-  mcmc_samples: 300
+  mcmc_samples: 0
   weekly_seasonality: true
   yearly_seasonality: true
   daily_seasonality: false

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -1,0 +1,15 @@
+import pandas as pd
+from pathlib import Path
+from prophet_analysis import load_time_series
+
+
+def test_ingestion_weekdays():
+    calls = load_time_series(Path('calls.csv'), metric='call')
+    visits = load_time_series(Path('visitors.csv'), metric='visit')
+    queries = pd.read_csv('queries.csv')['date']
+    calls_idx = calls.index
+    visits_idx = visits.index
+    queries_idx = pd.to_datetime(queries)
+    assert all(calls_idx.dayofweek < 5)
+    assert all(visits_idx.dayofweek < 5)
+    assert all(queries_idx.dt.dayofweek < 5)


### PR DESCRIPTION
## Summary
- reindex datasets to business day frequency and standardize regressors
- remove hard-coded event arrays and rely on holiday calendar
- add policy change impulse feature
- store results per run ID in pipeline
- add simple ingestion test for weekday check
- update default Prophet hyperparameters

## Testing
- `pytest -q` *(fails: `pytest` not found)*