### PR TITLE
Simplify Prophet regressors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prophet Forecast Analysis
 
-This project forecasts customer service call volume using [Prophet](https://github.com/facebook/prophet). It merges historical call, visitor and chatbot query data and trains a forecasting model. The script also produces diagnostic charts and exports predictions for the next business days.
+This project forecasts customer service call volume using [Prophet](https://github.com/facebook/prophet). It merges historical call, visitor and chatbot query data and trains a forecasting model. The script also produces diagnostic charts and exports predictions for the next business days. The model now uses only visitor and query counts plus a single policy indicator as additive regressors to avoid multicollinearity.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- limit extra regressors to visitors, queries and a single policy flag
- add them in additive mode
- mention the simplified regressor strategy in the docs

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*