### PR TITLE
Fix run forecast batch script

### DIFF
--- a/run forecast.bat
+++ b/run forecast.bat
@@ -1,4 +1,6 @@
-cd "C:\Users\anewe\OneDrive - Bernalillo County\Customer Data\Python Project"
+@echo off
+cd /d "%~dp0"
 
-cmd /k python prophet_analysis.py calls.csv visitors.csv queries.csv prophet_results --handle-outliers winsorize --use-transformation false
+python prophet_analysis.py calls.csv visitors.csv queries.csv prophet_results --handle-outliers winsorize --use-transformation false
 
+pause


### PR DESCRIPTION
## Summary
- fix quoting and relative path handling in `run forecast.bat`

## Testing
- `pytest -q` *(fails: command not found)*