### PR TITLE
Fix baseline export when openpyxl missing

### DIFF
--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -1477,8 +1477,10 @@ def export_baseline_forecast(df: pd.DataFrame, output_dir: Path) -> Path:
             metrics.to_excel(writer, sheet_name="Metrics", index=False)
             input_data.to_excel(writer, sheet_name="Input Data", index=False)
     else:
-        # Fallback: write CSV data with .xlsx extension if openpyxl is missing
+        # Fallback when openpyxl is unavailable - still export all data
         baseline_df.to_csv(excel_path, index=False)
+        metrics.to_csv(output_dir / "baseline_metrics.csv", index=False)
+        input_data.to_csv(output_dir / "baseline_input_data.csv", index=False)
 
     return excel_path
 


### PR DESCRIPTION
## Summary
- ensure metrics and input data are still exported when `openpyxl` is absent

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*