### PR TITLE
Set default Prophet hyperparameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,14 @@ The results, including forecasts and plots, will be saved in the specified outpu
 The exported Excel report now includes predictions for the previous 14 business days
 along with a forecast for the next business day. A naive baseline forecast for the
 same 14-day window and corresponding MAE, RMSE, and MAPE metrics are also included.
+
+## Model specification
+
+The Prophet model uses additive seasonality with linear growth. Default
+hyperparameters are:
+
+- `changepoint_prior_scale=0.05`
+- `holidays_prior_scale=5`
+- `regressor_prior_scale=0.05`
+
+You can modify these settings in `config.yaml` if desired.

--- a/config.yaml
+++ b/config.yaml
@@ -6,8 +6,10 @@ output: prophet_output
 model:
   seasonality_mode: additive
   seasonality_prior_scale: 0.05
-  holidays_prior_scale: 20
-  changepoint_prior_scale: 1.5
+  holidays_prior_scale: 5
+  changepoint_prior_scale: 0.05
+  regressor_prior_scale: 0.05
+  growth: linear
   mcmc_samples: 0
   weekly_seasonality: true
   yearly_seasonality: false

--- a/pipeline.py
+++ b/pipeline.py
@@ -58,6 +58,8 @@ def pipeline(config_path: Path):
         'weekly_seasonality': cfg['model']['weekly_seasonality'],
         'yearly_seasonality': cfg['model']['yearly_seasonality'],
         'daily_seasonality': cfg['model']['daily_seasonality'],
+        'growth': cfg['model'].get('growth', 'linear'),
+        'regressor_prior_scale': cfg['model'].get('regressor_prior_scale', 0.05),
     }
     model_params.update(best_params)
 


### PR DESCRIPTION
## Summary
- update config to use lower priors and expose regressor prior and growth
- pass new parameters through pipeline
- apply regressor_prior_scale in model training and ensemble
- adjust hyperparameter tuning defaults
- document model configuration in README

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*