### PR TITLE
Implement new cross‑validation discipline

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,11 @@ hyperparameters are:
 - `regressor_prior_scale=0.05`
 
 You can modify these settings in `config.yaml` if desired.
+
+## Cross-validation discipline
+
+The model is evaluated using a rolling origin cross‑validation scheme.
+By default the initial training window spans 270 days with a 30‑day
+horizon and evaluation period of 14 days. A model is accepted only if the
+mean absolute percentage error (MAPE) stays below 20% and the mean
+absolute error (MAE) is under 60 calls.

--- a/config.yaml
+++ b/config.yaml
@@ -15,6 +15,6 @@ model:
   yearly_seasonality: false
   daily_seasonality: false
 cross_validation:
-  initial: '365 days'
-  period: '30 days'
+  initial: '270 days'
+  period: '14 days'
   horizon: '30 days'

--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -1076,11 +1076,11 @@ def analyze_prophet_components(model, forecast, output_dir):
                 plt.close()
 
 
-def cross_validate_prophet(model, df, periods=30, horizon='60 days'):
+def cross_validate_prophet(model, df, periods=14, horizon='30 days', initial='270 days'):
     """Simple cross-validation for a Prophet model using a rolling origin."""
     df_cv = cross_validation(
         model,
-        initial='180 days',
+        initial=initial,
         period=f'{periods} days',
         horizon=horizon,
         parallel="processes",
@@ -1852,7 +1852,7 @@ def evaluate_prophet_model(model, prophet_df, cv_params=None, log_transform=Fals
         'lb_pvalue': lb['lb_pvalue']
     })
 
-    if mae > 60 or (mape == mape and mape > 15):
+    if mae > 60 or (mape == mape and mape > 20):
         logger.warning('Model performance below acceptance thresholds.')
     if autocorr_flag:
         logger.warning('Autocorrelation detected in residuals.')


### PR DESCRIPTION
## Summary
- set rolling cross-validation defaults in `config.yaml`
- document cross-validation discipline in README
- raise MAPE acceptance threshold to 20%
- update cross-validation helper defaults

## Testing
- `python -m unittest discover -v`