### PR TITLE
Fix Python <3.10 TypeError on import

### DIFF
--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -16,6 +16,8 @@ Example usage::
         --handle-outliers winsorize --use-transformation false --skip-feature-importance
 """
 
+from __future__ import annotations
+
 import os
 import sys
 


### PR DESCRIPTION
## Summary
- prevent Python 3.9 and earlier from evaluating new-style type hints

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*