### PR TITLE
Remove manual weekday features

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ The preprocessing step removes weekends and county holiday closures from the
 training set. Any days with zero recorded calls are flagged and treated as
 missing values. Call volumes above the 99th percentile are winsorized to
 reduce the impact of extreme spikes. Additional dummy variables mark periods for
-notice mail-outs, assessment deadlines and nearby federal holidays.
+notice mail-outs, assessment deadlines and nearby federal holidays. Weekly
+patterns are modeled using Prophet's built-in seasonality instead of manual
+weekday columns.
 
 The modeling pipeline applies a `log1p` transform to the target series to
 stabilize variance and then back‑transforms predictions to the original scale.

--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -509,10 +509,6 @@ def prepare_data(call_path,
     df['call_count'] = df['call_count'].clip(upper=clip_val)
 
     # Keep raw counts; z-scoring applied later
-    df['is_weekday'] = (df.index.dayofweek < 5).astype(int)
-
-
-
     # Feature engineering: lags and rolling stats for potential use as regressors
     logger.info("Creating lag and rolling features")
     for lag in [1, 3, 7]:
@@ -538,9 +534,6 @@ def prepare_data(call_path,
 
     # Create regressors dataframe for Prophet
     regressors = df.copy()
-
-    # Add day of week information for completeness
-    regressors["day_of_week"] = regressors.index.dayofweek
 
     if scale_features:
         # Standardize numeric regressors (z-score) except binary flags


### PR DESCRIPTION
## Summary
- rely solely on Prophet's built-in weekly seasonality
- update docs about weekly seasonality

## Testing
- `python prophet_analysis.py calls.csv visitors.csv queries.csv output_dir` *(fails: `to_datetime()` got an unexpected keyword argument 'format')*
- ❌ `pytest -q` *(failed to run: command not found)*