### PR TITLE
Enable weekly & yearly seasonality

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,8 +11,8 @@ model:
   regressor_prior_scale: 0.05
   growth: linear
   mcmc_samples: 0
-  weekly_seasonality: false
-  yearly_seasonality: false
+  weekly_seasonality: true
+  yearly_seasonality: 8
   daily_seasonality: false
   likelihood: normal
   uncertainty_samples: 300


### PR DESCRIPTION
## Summary
- enable Prophet weekly/yearly seasonality via config
- drop manual changepoint and weekend zeroing
- winsorize outliers with quantiles
- spline‑impute zero days and clip regressors
- deduplicate holiday dates

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*