### PR TITLE
Replace federal holidays with county holiday list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prophet Forecast Analysis
 
-This project forecasts customer service call volume using [Prophet](https://github.com/facebook/prophet). It merges historical call, visitor and chatbot query data and trains a forecasting model. The script also produces diagnostic charts and exports predictions for upcoming business days. In addition to visitor and query counts, the model now includes explicit flags for notice-of-value mail-outs, assessment deadlines, federal holidays and a short campaign period. Prophet's built‑in yearly and weekly seasonalities are disabled in favor of these custom regressors.
+This project forecasts customer service call volume using [Prophet](https://github.com/facebook/prophet). It merges historical call, visitor and chatbot query data and trains a forecasting model. The script also produces diagnostic charts and exports predictions for upcoming business days. In addition to visitor and query counts, the model now includes explicit flags for notice-of-value mail-outs, assessment deadlines, county holidays and a short campaign period. Prophet's built‑in yearly and weekly seasonalities are disabled in favor of these custom regressors.
 
 ## Requirements
 
@@ -73,7 +73,7 @@ The preprocessing step removes weekends and county holiday closures from the
 training set. Any days with zero recorded calls are flagged and treated as
 missing values. Call volumes above the 99th percentile are winsorized to
 reduce the impact of extreme spikes. Dummy variables mark periods for notice
-mail-outs, assessment deadlines, a May 2025 campaign and nearby federal
+mail-outs, assessment deadlines, a May 2025 campaign and nearby county
 holidays. Only a 3‑day moving average of visitor counts and raw chatbot
 queries are retained as regressors.
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -16,7 +16,7 @@ from prophet_analysis import (
 )
 from datetime import datetime
 import pandas as pd
-from pandas.tseries.holiday import USFederalHolidayCalendar
+from holidays_calendar import get_holidays_dataframe
 import logging
 
 
@@ -66,8 +66,10 @@ def pipeline(config_path: Path):
     model_params.update(best_params)
 
     idx = df.index
-    holiday_cal = USFederalHolidayCalendar()
-    holiday_dates = holiday_cal.holidays(start=idx.min(), end=idx.max())
+    holiday_df = get_holidays_dataframe()
+    mask = (holiday_df['event'] == 'county_holiday') & \
+           (holiday_df['date'] >= idx.min()) & (holiday_df['date'] <= idx.max())
+    holiday_dates = holiday_df.loc[mask, 'date']
     deadline_dates = pd.date_range(start=idx.min(), end=idx.max(), freq='MS')
     holidays = create_prophet_holidays(holiday_dates, deadline_dates, [])
 

--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -46,7 +46,7 @@ from sklearn.metrics import mean_squared_error, mean_absolute_error
 from sklearn.feature_selection import mutual_info_regression
 from statsmodels.stats.outliers_influence import variance_inflation_factor
 from statsmodels.stats.diagnostic import acorr_ljungbox
-from pandas.tseries.holiday import USFederalHolidayCalendar
+from holidays_calendar import get_holidays_dataframe
 
 # Import Prophet
 try:
@@ -499,8 +499,10 @@ def prepare_data(call_path,
     logger.info(f"Creating unified date range from {start} to {end}")
     idx = pd.date_range(start=start, end=end, freq="B")
 
-    holiday_cal = USFederalHolidayCalendar()
-    holiday_dates = holiday_cal.holidays(start=idx.min(), end=idx.max())
+    holiday_df = get_holidays_dataframe()
+    mask = (holiday_df['event'] == 'county_holiday') & \
+           (holiday_df['date'] >= idx.min()) & (holiday_df['date'] <= idx.max())
+    holiday_dates = holiday_df.loc[mask, 'date']
     idx = idx.drop(holiday_dates)
 
     # Build main dataframe


### PR DESCRIPTION
## Summary
- pull in county holidays from `holidays_calendar.get_holidays_dataframe`
- drop references to USFederalHolidayCalendar
- update documentation to mention county holidays instead of federal holidays

## Testing
- `python -m py_compile pipeline.py prophet_analysis.py holidays_calendar.py`