### PR TITLE
Fix cross-validation crashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,11 @@ The model is evaluated using a rolling origin cross‑validation scheme.
 The default initial window spans 365 days with a 30‑day horizon and
 30‑day evaluation period. A model is accepted only if the mean absolute
 error stays below 15% of the average call volume.
+
+### Windows compatibility
+
+Prophet's diagnostics spawn multiple worker processes. On Windows the
+default Tkinter-backed Matplotlib GUI conflicts with this and can raise
+``Operation not permitted`` errors from CmdStan. The analysis script now
+forces a headless Matplotlib backend and runs cross‑validation using
+threads to avoid the issue.


### PR DESCRIPTION
## Summary
- force headless matplotlib backend
- use thread-based cross validation
- correct quick-mode indexing for feature importance
- guard dtype cast in ensemble build
- document Windows cross-validation fix

## Testing
- `python -m py_compile prophet_analysis.py pipeline.py naive_forecast.py holidays_calendar.py`