### PR TITLE
Fix pandas stub missing __version__

### DIFF
--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -3,6 +3,8 @@ import math
 from datetime import datetime, date, timedelta
 from types import SimpleNamespace
 
+__version__ = "1.5.3"
+
 __all__ = [
     'DataFrame',
     'Series',


### PR DESCRIPTION
## Summary
- add a `__version__` attribute to the pandas stub

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*