### PR TITLE
Fix pandas/statsmodels compatibility docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,17 @@ Install dependencies with the exact versions pinned in `requirements.txt`:
 pip install -r requirements.txt
 ```
 
-The pipeline currently relies on `statsmodels` 0.14 which is incompatible with
-`pandas` 2.0 and later. If you see an error like `ModuleNotFoundError: No module
-named 'pandas.util'`, ensure pandas 1.x is installed:
+The pipeline requires `statsmodels` **0.14.2** or newer when using
+`pandas` 2.0+. Older releases of `statsmodels` still reference the
+removed `pandas.util` module. To resolve a version clash either upgrade
+`statsmodels` or pin pandas below 2.0 **but do not mix both approaches**:
 
 ```bash
-pip install "pandas<2"
+# Option 1: upgrade statsmodels for pandas >= 2.0
+python -m pip install --upgrade "statsmodels>=0.14.2"
+
+# Option 2: keep the older statsmodels and install pandas < 2.0
+python -m pip install "pandas<2.0"
 ```
 
 ### Stub libraries

--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -54,11 +54,10 @@ from sklearn.feature_selection import mutual_info_regression
 
 # Check pandas/statsmodels compatibility before importing heavy submodules
 _PD_MAJOR = int(pd.__version__.split(".")[0])
-_SM_VERSION = tuple(int(p) for p in statsmodels.__version__.split(".")[:2])
-if _PD_MAJOR >= 2 and _SM_VERSION <= (0, 14):
+_SM_VERSION = tuple(int(p) for p in statsmodels.__version__.split(".")[:3])
+if _PD_MAJOR >= 2 and _SM_VERSION < (0, 14, 2):
     raise ImportError(
-        "pandas>=2.0 is incompatible with statsmodels<=0.14. "
-        "Install pandas<2 or upgrade statsmodels."
+        "pandas>=2.0 requires statsmodels>=0.14.2 or pandas<2 must be installed."
     )
 
 from statsmodels.stats.outliers_influence import variance_inflation_factor

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Core dependencies
-pandas==1.5.3
+pandas>=2.0
 numpy==1.23.5
 matplotlib==3.7.1
 seaborn==0.12.2
@@ -8,4 +8,4 @@ prophet==1.1.5
 openpyxl==3.1.2
 
 ruamel.yaml==0.17.32
-statsmodels==0.14.0
+statsmodels>=0.14.2


### PR DESCRIPTION
## Summary
- document how to resolve pandas/statsmodels clash
- update requirement versions
- tighten compatibility check in `prophet_analysis.py`

## Testing
- `python -m py_compile prophet_analysis.py`
- `python -m py_compile pipeline.py`
