### PR TITLE
Improve error guidance for real libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,16 @@ Windows text editor.
 
 ## Usage
 
+Before running the scripts ensure the real third-party packages are used by
+setting the environment variable `USE_REAL_LIBS` to `1`. This disables the
+lightweight stub modules bundled with the repository.
+
 Run the analysis by providing the three input CSV files and an optional output directory:
 
 ```bash
-python prophet_analysis.py calls.csv visitors.csv queries.csv output_dir
+set USE_REAL_LIBS=1 && python pipeline.py config.yaml            # Windows
+# or
+USE_REAL_LIBS=1 python pipeline.py config.yaml                    # Unix
 ```
 
 The CLI now serves as a thin wrapper around the YAML-driven pipeline. All model

--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -33,6 +33,11 @@ if _USE_REAL_LIBS:
         if os.path.abspath(p or os.getcwd()) != _THIS_DIR
     ]
 import matplotlib
+if not hasattr(matplotlib, "use"):
+    raise ImportError(
+        "The bundled matplotlib stub was imported. "
+        "Install the real matplotlib package and set USE_REAL_LIBS=1 to use it."
+    )
 matplotlib.use("Agg")  # ensure headless backend for multiprocessing safety
 import pandas as pd
 import numpy as np


### PR DESCRIPTION
## Summary
- clarify how to run the forecast with real dependencies
- raise a helpful error when the matplotlib stub is imported

## Testing
- `pytest -q` *(fails: command not found)*