### PR TITLE
Add business-day regressor and residual AR(1) check

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -21,5 +21,5 @@ model:
   uncertainty_samples: 300
 cross_validation:
   initial: '365 days'
-  period: '30 days'
-  horizon: '30 days'
+  period: '14 days'
+  horizon: '14 days'

--- a/pipeline.py
+++ b/pipeline.py
@@ -103,11 +103,12 @@ def run_forecast(cfg: dict) -> None:
     )
 
     cv_params = cfg.get('cross_validation', {})
-    df_cv, horizon_table, summary, diag = evaluate_prophet_model(
+    df_cv, horizon_table, summary, diag, _scale = evaluate_prophet_model(
         model,
         prophet_df,
         cv_params=cv_params,
         log_transform=True,
+        forecast=forecast,
     )
     summary.to_csv(out_dir / "summary.csv", index=False)
     horizon_table.to_csv(out_dir / "horizon_metrics.csv", index=False)


### PR DESCRIPTION
## Summary
- include campaign_may2025 and is_business_day flags during data prep
- keep county holidays in the business‑day index
- scale intervals to maintain 90% coverage
- correct forecasts with AR(1) residual model when Ljung–Box fails
- update cross‑validation schedule
- export to prophet_call_predictions_v4.xlsx

## Testing
- `ruff check config.yaml pipeline.py prophet_analysis.py` *(fails: numerous style errors)*
- `pytest -q` *(fails: command not found)*