### PR TITLE
Add weekend days to Prophet pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,10 @@ holidays, notice mail-outs and the May 2025 campaign period.
 
 ### Data exclusions
 
-The preprocessing step removes weekends and county holiday closures from the
-training set. Any days with zero recorded calls are flagged and treated as
-missing values. Call volumes above the 99th percentile are winsorized to
+The preprocessing step now creates a continuous daily index. Weekend rows are
+inserted with zero call, visit and chatbot counts. Any zero values on weekdays
+are flagged and treated as missing so they can be interpolated. Call volumes
+above the 99th percentile are winsorized to
 reduce the impact of extreme spikes. Dummy variables mark periods for notice
 mail-outs, assessment deadlines, a May 2025 campaign and nearby county
 holidays. Only a 3‑day moving average of visitor counts and raw chatbot


### PR DESCRIPTION
## Summary
- inject missing weekend rows when preparing the dataset
- flag weekday zeros for interpolation only
- update `is_business_day` logic to exclude weekends
- document new weekend handling in README

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*