### PR TITLE
Fix NaN handling in forecast pipeline

### DIFF
--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -942,6 +942,8 @@ def train_prophet_model(
             logger.warning(
                 f"Found {future[col].isna().sum()} NaN values in {col} after merge"
             )
+            # Prophet cannot handle NaNs, so replace missing values with 0
+            future[col] = future[col].fillna(0)
     
     # Make forecast
     logger.info("Making forecast")


### PR DESCRIPTION
## Summary
- fill NaNs in future regressors when merging

## Testing
- `ruff check prophet_analysis.py` *(fails: many style issues)*
- `python -m pytest -q` *(fails: No module named pytest)*