### PR TITLE
Fix NaNs in chatbot counts

### DIFF
--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -544,6 +544,14 @@ def prepare_data(call_path,
         "chatbot_count": chat.reindex(idx),
     }, index=idx)
 
+    # Fill missing chatbot counts before transformations
+    df["chatbot_count"] = (
+        df["chatbot_count"].interpolate()
+        .ffill()
+        .bfill()
+        .astype(float)
+    )
+
     df["is_weekend"] = (df.index.dayofweek >= 5).astype(int)
 
     # Flag zero-call weekdays and treat them as missing

--- a/tests/test_prepare_chatbot.py
+++ b/tests/test_prepare_chatbot.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+from prophet_analysis import prepare_data
+
+def test_chatbot_counts_no_nan():
+    df, _ = prepare_data(Path('calls.csv'), Path('visitors.csv'), Path('queries.csv'))
+    assert not df['chatbot_count'].isna().any()


### PR DESCRIPTION
## Summary
- handle missing `chatbot_count` by interpolating and filling gaps
- test that prepare_data returns no NaNs in chatbot_count

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*
- `python -m flake8` *(fails: No module named flake8)*