### PR TITLE
Implement seasonal naive baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,10 @@ stabilize variance and then back‑transforms predictions to the original scale.
 
 The results, including forecasts and plots, will be saved in the specified output directory.
 The exported Excel report (`prophet_call_predictions_v3.xlsx`) now includes
-predictions for the previous 14 business days
-along with a forecast for the next business day. A naive baseline forecast for the
-same 14-day window and corresponding MAE, RMSE, and MAPE metrics are also included.
+predictions for the previous 14 business days along with a forecast for the next
+business day. A seasonal naive baseline forecast using the call volume from the
+same weekday in the prior week and the corresponding MAE, RMSE, and MAPE metrics
+are also included.
 
 ## Model specification
 

--- a/naive_forecast.py
+++ b/naive_forecast.py
@@ -1,8 +1,9 @@
-"""Naive forecast for call volumes using previous day's value.
+"""Seasonal naive forecast using last week's value.
 
-This script reads `calls.csv` and produces predictions for the last
-14 days using the value from the prior day as the prediction. It also
-reports MAE, RMSE and MAPE to compare predictions to actual values.
+This script reads ``calls.csv`` and produces predictions for the last
+14 days using the value from the same weekday in the prior week as the
+prediction. It also reports MAE, RMSE and MAPE to compare predictions
+to actual values.
 """
 import csv
 from datetime import datetime
@@ -32,14 +33,14 @@ with open('calls.csv') as f:
 # Ensure data is sorted by date
 rows.sort(key=lambda x: x[0])
 
-# Need one extra day for the first prediction
-recent = rows[-15:]
+# Need one week of extra history for the seasonal naive baseline
+recent = rows[-21:]
 
 preds = []
 acts = []
 dates = []
-for i in range(1, len(recent)):
-    pred = recent[i - 1][1]
+for i in range(7, len(recent)):
+    pred = recent[i - 7][1]
     actual = recent[i][1]
     preds.append(pred)
     acts.append(actual)


### PR DESCRIPTION
## Summary
- implement seasonal naive baseline using prior week's volume
- update baseline script to match new approach
- clarify baseline description in README

## Testing
- `pytest -q` *(fails: command not found)*
- `flake8` *(fails: command not found)*