### PR TITLE
Update batch script and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ set USE_REAL_LIBS=1  # Windows
 export USE_REAL_LIBS=1  # Unix
 ```
 
-This variable is already set in the provided `run forecast.bat` script.
-If the batch file does not run when double-clicked, ensure it uses Windows
+This variable is already set in the provided `run_forecast.bat` script.
+The batch file accepts an optional output directory as a second argument. If it
+does not run when double-clicked, ensure it uses Windows
 line endings (CRLF). Some Git tools may check out the repository with Unix
 line endings, which can cause `cmd.exe` to ignore the script. You can convert
 the file with a tool like `unix2dos` or by opening and resaving it in a

--- a/run_forecast.bat
+++ b/run_forecast.bat
@@ -1,12 +1,20 @@
 @echo off
 cd /d "%~dp0"
 
-REM Run the full forecasting pipeline. Pass a custom config path as the first
-REM argument or default to "config.yaml" if none is provided.
+REM Run the full forecasting pipeline. Provide a config path as the first
+REM argument or default to "config.yaml". An optional second argument sets
+REM the output directory which will be forwarded to the pipeline.
+
 set "CONFIG=%1"
 if "%CONFIG%"=="" set "CONFIG=config.yaml"
 
+set "OUT=%2"
 set USE_REAL_LIBS=1
-python pipeline.py "%CONFIG%"
+
+if not "%OUT%"=="" (
+    python pipeline.py "%CONFIG%" --out "%OUT%"
+) else (
+    python pipeline.py "%CONFIG%"
+)
 
 pause


### PR DESCRIPTION
## Summary
- allow specifying an output directory in `run_forecast.bat`
- document the new argument in the README and fix script name

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*