### PR TITLE
Improve baseline metrics and scaler docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,16 @@ The model is evaluated using a rolling origin cross‑validation scheme.
 The default initial window spans 365 days with a 30-day horizon and updates every 7 days. A model is accepted only if the mean absolute
 error stays below 15% of the average call volume.
 
+### Scaling details
+
+The target series ``call_count`` is standardized prior to model fitting. Each
+run saves the fitted ``StandardScaler`` as ``call_scaler.pkl`` in the output
+directory. The pickle stores the mean and standard deviation used for the
+transformation. During evaluation and when exporting forecasts the predictions
+are inverse transformed so that metrics reflect the original call counts.
+When reusing the scaler ensure the underlying data distribution matches the
+stored parameters.
+
 ### Windows compatibility
 
 Prophet's diagnostics spawn multiple worker processes. On Windows the

--- a/pipeline.py
+++ b/pipeline.py
@@ -125,16 +125,11 @@ def run_forecast(cfg: dict) -> None:
     export_prophet_forecast(model, forecast, df, out_dir, scaler=scaler)
     export_baseline_forecast(df, out_dir)
 
-    baseline_df, baseline_metrics = compute_naive_baseline(df)
-    mae_b = baseline_metrics.loc[baseline_metrics['metric']=='MAE','value'].iloc[0]
-    rmse_b = baseline_metrics.loc[baseline_metrics['metric']=='RMSE','value'].iloc[0]
-    metrics_baseline = pd.DataFrame([{
-        'model': 'baseline',
-        'horizon': 1,
-        'MAE': mae_b,
-        'RMSE': rmse_b,
-        'coverage': float('nan'),
-    }])
+    baseline_df, baseline_metrics, baseline_horizon = compute_naive_baseline(df)
+    cov_b = baseline_metrics.loc[baseline_metrics['metric'] == 'Coverage', 'value'].iloc[0]
+    metrics_baseline = baseline_horizon.rename(columns={'horizon_days': 'horizon'}).copy()
+    metrics_baseline['model'] = 'baseline'
+    metrics_baseline['coverage'] = cov_b
 
     coverage = summary.loc[summary['metric']=='Coverage','value'].iloc[0]
     prophet_metrics = horizon_table.rename(columns={'horizon_days':'horizon'}).copy()


### PR DESCRIPTION
## Summary
- compute baseline coverage and horizon metrics
- include baseline metrics in pipeline output
- describe StandardScaler usage in README
- expand horizon table to include 1-day results

## Testing
- `ruff check .` *(fails: unrecognized subcommand / many errors)*
- `black --check .` *(fails: would reformat files)*
- `pytest -q` *(fails: command not found)*