### PR TITLE
Add SQLite ingestion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,19 @@ The CLI now serves as a thin wrapper around the YAML-driven pipeline. All model
 parameters continue to be read from `config.yaml`. The command simply overrides
 the input and output paths before calling the pipeline.
 
+If your data resides in a SQLite database you can point the loader to the
+appropriate tables using a `path.db:table` notation in `config.yaml`:
+
+```yaml
+data:
+  calls: mydata.db:calls
+  visitors: mydata.db:visits
+  queries: mydata.db:queries
+```
+
+The pipeline detects the `.db` extension and automatically queries the database
+instead of reading CSV files.
+
 ### Data pipeline
 
 To run only the preprocessing step and export a single CSV with engineered

--- a/data_preparation.py
+++ b/data_preparation.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 from prophet_analysis import (
     load_time_series as _load_time_series,
+    load_time_series_sqlite as _load_time_series_sqlite,
     verify_date_formats as _verify_date_formats,
     build_flag_series as _build_flag_series,
     prepare_data as _prepare_data,
@@ -15,6 +16,11 @@ from prophet_analysis import (
 def load_time_series(*args, **kwargs):
     """Proxy to :func:`prophet_analysis.load_time_series`."""
     return _load_time_series(*args, **kwargs)
+
+
+def load_time_series_sqlite(*args, **kwargs):
+    """Proxy to :func:`prophet_analysis.load_time_series_sqlite`."""
+    return _load_time_series_sqlite(*args, **kwargs)
 
 
 def verify_date_formats(*args, **kwargs):

--- a/tests/test_sqlite_ingestion.py
+++ b/tests/test_sqlite_ingestion.py
@@ -1,0 +1,21 @@
+import sqlite3
+import pandas as pd
+from pathlib import Path
+from prophet_analysis import load_time_series, load_time_series_sqlite
+
+
+def test_load_time_series_sqlite(tmp_path):
+    df = pd.read_csv('calls.csv')
+    df.columns = ['date', 'call_count']
+    db_path = tmp_path / 'data.db'
+    conn = sqlite3.connect(db_path)
+    df.to_sql('calls', conn, index=False)
+    conn.close()
+
+    series_db = load_time_series_sqlite(db_path, 'calls', value_col='call_count')
+    series_csv = load_time_series(Path('calls.csv'), metric='call')
+    assert series_db.equals(series_csv)
+
+    path = Path(str(db_path) + ':calls')
+    series_auto = load_time_series(path, metric='call')
+    assert series_auto.equals(series_csv)


### PR DESCRIPTION
## Summary
- support loading data from SQLite
- expose the new helper in data_preparation
- document SQLite option in the README
- test SQLite ingestion logic

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*