### PR TITLE
Fix NaNs in Prophet future lag features

### DIFF
--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -1047,7 +1047,7 @@ def train_prophet_model(
     check_cols = [
         'post_policy', 'is_campaign', 'campaign_May2025', 'visit_ma3',
         'chatbot_count', 'notice_flag', 'deadline_flag', 'county_holiday_flag',
-        'holiday_flag', 'closure_flag'
+        'holiday_flag', 'closure_flag', 'call_lag1', 'call_lag7'
     ]
     for col in check_cols:
         if col in future.columns and future[col].isna().any():


### PR DESCRIPTION
## Summary
- check and fill NaN values for `call_lag1` and `call_lag7` in future dataframe

## Testing
- `python -m py_compile prophet_analysis.py`
- `python -m unittest discover -s tests` *(fails: ImportError due to missing dependencies)*