### PR TITLE
Simplify Prophet inputs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,14 +7,14 @@ model:
   seasonality_mode: additive
   seasonality_prior_scale: 0.01
   holidays_prior_scale: 5
-  changepoint_prior_scale: 0.2
+  changepoint_prior_scale: 0.05
   n_changepoints: 25
   changepoint_range: 0.9
   regressor_prior_scale: 0.05
   growth: logistic
   mcmc_samples: 0
-  interval_width: 0.95
-  weekly_seasonality: false
+  interval_width: 0.8
+  weekly_seasonality: true
   yearly_seasonality: auto
   daily_seasonality: false
   likelihood: poisson

--- a/tests/test_feature_alignment.py
+++ b/tests/test_feature_alignment.py
@@ -30,7 +30,8 @@ def test_no_feature_mismatch_after_drop():
     holidays = create_prophet_holidays(
         holiday_df.loc[mask, 'date'],
         pd.date_range(df.index.min(), df.index.max(), freq='MS'),
-        []
+        closure_dates=[],
+        press_release_dates=[]
     )
     with patch('prophet_analysis.Prophet', DummyProphet), \
          patch('prophet_analysis.drop_collinear_features', side_effect=dropping_cols):

--- a/tests/test_pipeline_alignment.py
+++ b/tests/test_pipeline_alignment.py
@@ -54,7 +54,8 @@ def test_pipeline_alignment():
     holidays = create_prophet_holidays(
         holiday_df.loc[mask, "date"],
         pd.date_range(df.index.min(), df.index.max(), freq="MS"),
-        [],
+        closure_dates=[],
+        press_release_dates=[],
     )
     with patch("prophet_analysis.Prophet", DummyProphet):
         model, forecast, future = train_prophet_model(


### PR DESCRIPTION
## Summary
- remove scaling of the target variable
- enable Prophet's built‑in weekly seasonality
- tighten changepoint and interval settings
- drop lagged and policy regressors
- pass closure days in the holiday dataframe
- update tests for new `create_prophet_holidays` signature

## Testing
- `pytest -q` *(fails: command not found)*