### PR TITLE
Fix DatetimeIndex handling in holiday creation

### DIFF
--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -741,8 +741,15 @@ def create_prophet_holidays(holiday_dates, deadline_dates, closure_dates=None, p
         'upper_window': 0
     })
     
-    press_release_dates = press_release_dates or []
-    closure_dates = closure_dates or []
+    if press_release_dates is None:
+        press_release_dates = []
+    elif isinstance(press_release_dates, pd.DatetimeIndex):
+        press_release_dates = press_release_dates.to_list()
+
+    if closure_dates is None:
+        closure_dates = []
+    elif isinstance(closure_dates, pd.DatetimeIndex):
+        closure_dates = closure_dates.to_list()
 
     # Create press release DataFrame
     press_releases = pd.DataFrame({


### PR DESCRIPTION
## Summary
- prevent ambiguous truthiness errors in `create_prophet_holidays`
- handle `DatetimeIndex` inputs directly

## Testing
- `black --check prophet_analysis.py` *(fails: would reformat file)*
- `isort --check-only prophet_analysis.py`
- `mypy prophet_analysis.py`
- `pytest` *(fails: command not found)*