### PR TITLE
Add MAPE metric and next-day predictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,9 @@ The results, including forecasts and plots, will be saved in the specified outpu
 The exported Excel report (`prophet_call_predictions_v3.xlsx`) now includes
 predictions for the previous 14 business days along with a forecast for the next
 business day. A seasonal naive baseline forecast using the call volume from the
-same weekday in the prior week and the corresponding MAE and RMSE metrics
-are also included.
+same weekday in the prior week and the corresponding MAE, RMSE and MAPE metrics
+are also included. The report additionally lists the predicted call volume for
+the upcoming business day in a dedicated sheet.
 
 ## Model specification
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -162,8 +162,8 @@ def run_forecast(cfg: dict) -> None:
     prophet_metrics["coverage"] = coverage
     metrics = pd.concat(
         [
-            metrics_baseline,
-            prophet_metrics[["model", "horizon", "MAE", "RMSE", "coverage"]],
+            metrics_baseline[["model", "horizon", "MAE", "RMSE", "MAPE", "coverage"]],
+            prophet_metrics[["model", "horizon", "MAE", "RMSE", "MAPE", "coverage"]],
         ],
         ignore_index=True,
     )


### PR DESCRIPTION
## Summary
- calculate MAPE in `compute_naive_baseline`
- include MAPE in cross-validation metrics
- output MAPE in exported Excel report
- capture new metrics in pipeline outputs
- document next-day prediction sheet and MAPE in README

## Testing
- `python -m py_compile prophet_analysis.py pipeline.py naive_forecast.py modeling.py data_pipeline.py data_preparation.py holidays_calendar.py prophet_analysis.py`
- `pytest -q` *(fails: command not found)*
- `flake8 --version` *(fails: command not found)*