### PR TITLE
Update batch script

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ export USE_REAL_LIBS=1  # Unix
 ```
 
 This variable is already set in the provided `run_forecast.bat` script.
-The batch file accepts an optional output directory as a second argument. If it
+The batch file accepts an optional output directory as a second argument and
+honors a `PYTHON` environment variable so you can choose a custom interpreter.
+If it
 does not run when double-clicked, ensure it uses Windows
 line endings (CRLF). Some Git tools may check out the repository with Unix
 line endings, which can cause `cmd.exe` to ignore the script. You can convert

--- a/run_forecast.bat
+++ b/run_forecast.bat
@@ -9,12 +9,13 @@ set "CONFIG=%1"
 if "%CONFIG%"=="" set "CONFIG=config.yaml"
 
 set "OUT=%2"
+if "%PYTHON%"=="" set "PYTHON=python"
 set USE_REAL_LIBS=1
 
 if not "%OUT%"=="" (
-    python pipeline.py "%CONFIG%" --out "%OUT%"
+    %PYTHON% pipeline.py "%CONFIG%" --out "%OUT%"
 ) else (
-    python pipeline.py "%CONFIG%"
+    %PYTHON% pipeline.py "%CONFIG%"
 )
 
 pause


### PR DESCRIPTION
## Summary
- allow overriding the python interpreter used by `run_forecast.bat`
- document the new `PYTHON` variable in the README

## Testing
- `pytest -q` *(fails: command not found)*
- `ruff check .` *(fails: lint errors)*