### PR TITLE
Add binary regressors for campaign and shock events

### DIFF
--- a/tests/test_feature_alignment.py
+++ b/tests/test_feature_alignment.py
@@ -9,9 +9,18 @@ from tests.test_pipeline_alignment import DummyProphet
 
 
 def dropping_cols(df, threshold=0.9, return_dropped=False):
-    dropped = [c for c in [
-        'holiday_flag', 'is_campaign', 'campaign_May2025', 'is_weekend'
-    ] if c in df.columns]
+    dropped = [
+        c
+        for c in [
+            'holiday_flag',
+            'is_campaign',
+            'campaign_May2025',
+            'is_weekend',
+            'press_release_flag',
+            'post_policy',
+        ]
+        if c in df.columns
+    ]
     df = df.drop(columns=dropped)
     if return_dropped:
         return df, dropped


### PR DESCRIPTION
## Summary
- include press release flags in data prep
- return campaign, post-policy, and press release flags as Prophet regressors
- support these regressors when training Prophet models
- adjust feature alignment test for new regressors

## Testing
- `ruff check prophet_analysis.py tests/test_feature_alignment.py | head -n 20`
- `python -m pytest -q` *(fails: No module named pytest)*