### PR TITLE
Add lagged call count regressors

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ above the 99th percentile are winsorized to
 reduce the impact of extreme spikes. Dummy variables mark periods for notice
 mail-outs, assessment deadlines, a May 2025 campaign and nearby county
 holidays. Only a 3‑day moving average of visitor counts and raw chatbot
-queries are retained as regressors.
+queries are retained as regressors. Lagged call counts at 1- and 7-day intervals are also used as regressors to mitigate autocorrelation.
 
 The modeling pipeline applies a `log1p` transform to the target series to
 stabilize variance and then back‑transforms predictions to the original scale.

--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -756,6 +756,8 @@ def prepare_data(call_path,
     important_regs = [
         "visit_ma3",
         "chatbot_count",
+        "call_lag1",
+        "call_lag7",
         "deadline_flag",
         "notice_flag",
         "is_campaign",
@@ -995,6 +997,8 @@ def train_prophet_model(
     important_regressors = [
         'visit_ma3',
         'chatbot_count',
+        'call_lag1',
+        'call_lag7',
         'notice_flag',
         'deadline_flag',
         'is_campaign',
@@ -1042,6 +1046,8 @@ def train_prophet_model(
     # Required regressors only
     future_regs['visit_ma3'] = 0
     future_regs['chatbot_count'] = 0
+    future_regs['call_lag1'] = 0
+    future_regs['call_lag7'] = 0
     future_regs['notice_flag'] = 0
     future_regs['deadline_flag'] = 0
     future_regs['is_campaign'] = 0
@@ -1081,6 +1087,8 @@ def train_prophet_model(
     check_cols = [
         'visit_ma3',
         'chatbot_count',
+        'call_lag1',
+        'call_lag7',
         'notice_flag',
         'deadline_flag',
         'is_campaign',
@@ -1185,6 +1193,8 @@ def create_simple_ensemble(prophet_df, holidays_df, regressors_df):
     important_regressors = [
         'visit_ma3',
         'chatbot_count',
+        'call_lag1',
+        'call_lag7',
         'notice_flag',
         'deadline_flag',
     ]


### PR DESCRIPTION
## Summary
- add lag-1 and lag-7 regressors in preprocessing and modeling
- ensure future data includes lagged regressors
- update README with new features

## Testing
- `ruff check . | head`
- `pytest -q` *(fails: No module named pytest)*