### PR TITLE
Add configurable Box-Cox transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,10 @@ mail-outs, assessment deadlines, a May 2025 campaign and nearby county
 holidays. Only a 3‑day moving average of visitor counts and raw chatbot
 queries are retained as regressors. Lagged call counts at 1- and 7-day intervals are also used as regressors to mitigate autocorrelation.
 
-The modeling pipeline applies a `log1p` transform to the target series to
-stabilize variance and then back‑transforms predictions to the original scale.
+The modeling pipeline applies either a logarithmic or Box‑Cox transform to the
+target series (controlled by `model.transform` in `config.yaml`). By default a
+`log1p` transform is used and predictions are back‑transformed to the original
+scale.
 
 The results, including forecasts and plots, will be saved in the specified output directory.
 The exported Excel report (`prophet_call_predictions_v3.xlsx`) now includes

--- a/config.yaml
+++ b/config.yaml
@@ -12,6 +12,7 @@ model:
   changepoint_range: 0.9
   regressor_prior_scale: 0.05
   growth: logistic
+  transform: log
   mcmc_samples: 0
   interval_width: 0.8
   weekly_seasonality: true

--- a/pipeline.py
+++ b/pipeline.py
@@ -127,8 +127,8 @@ def run_forecast(cfg: dict) -> None:
         future_periods=30,
         model_params=model_params,
         prophet_kwargs=prophet_kwargs,
-        log_transform=True,
         likelihood=cfg["model"].get("likelihood", "normal"),
+        transform=cfg["model"].get("transform", "log"),
     )
 
     cv_params = cfg.get("cross_validation", {})
@@ -136,9 +136,9 @@ def run_forecast(cfg: dict) -> None:
         model,
         prophet_df,
         cv_params=cv_params,
-        log_transform=True,
         forecast=forecast,
         scaler=None,
+        transform=cfg["model"].get("transform", "log"),
     )
     summary.to_csv(out_dir / "summary.csv", index=False)
     horizon_table.to_csv(out_dir / "horizon_metrics.csv", index=False)


### PR DESCRIPTION
## Summary
- support optional log or Box-Cox transform in `train_prophet_model`
- apply inverse transform in evaluation and forecasting
- expose `model.transform` option in `config.yaml`
- wire new option through `pipeline.py`
- document transformation options

## Testing
- `ruff check pipeline.py prophet_analysis.py` *(fails: E402 Module level import not at top of file, F401 etc.)*
- `pytest -q` *(fails: command not found)*