### PR TITLE
Increase forecast interval width

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -14,7 +14,7 @@ model:
   growth: logistic
   transform: log
   mcmc_samples: 0
-  interval_width: 0.8
+  interval_width: 0.9
   weekly_seasonality: true
   yearly_seasonality: auto
   daily_seasonality: false

--- a/pipeline.py
+++ b/pipeline.py
@@ -97,7 +97,7 @@ def run_forecast(cfg: dict) -> None:
         "n_changepoints": cfg["model"].get("n_changepoints", 8),
         "changepoint_range": cfg["model"].get("changepoint_range", 0.8),
         "mcmc_samples": cfg["model"]["mcmc_samples"],
-        "interval_width": cfg["model"].get("interval_width", 0.8),
+        "interval_width": cfg["model"].get("interval_width", 0.9),
         "growth": cfg["model"].get("growth", "linear"),
         "regressor_prior_scale": cfg["model"].get("regressor_prior_scale", 0.05),
     }

--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -388,7 +388,7 @@ def tune_prophet_hyperparameters(prophet_df, prophet_kwargs=None):
         try:
             m = Prophet(
                 growth='linear',
-                interval_width=0.8,
+                interval_width=0.9,
                 seasonality_mode='additive',
                 n_changepoints=25,
                 changepoint_range=0.9,
@@ -1013,7 +1013,7 @@ def train_prophet_model(
         'mcmc_samples': 0,
         'uncertainty_samples': 300,
         'growth': 'logistic',
-        'interval_width': 0.8
+        'interval_width': 0.9
     }
 
     reg_prior_scale = 0.05


### PR DESCRIPTION
## Summary
- widen interval_width to 0.9 in config and code

## Testing
- `python -m unittest discover -s tests -p "test_*.py"` *(fails: ModuleNotFoundError: No module named 'matplotlib')*
- `USE_REAL_LIBS=1 python -m unittest discover -s tests -p "test_*.py"` *(fails: ModuleNotFoundError: No module named 'matplotlib')*