### PR TITLE
Fix metrics export to preserve NaNs

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -32,9 +32,14 @@ from data_preparation import (create_prophet_holidays, prepare_data,
 from holidays_calendar import get_holidays_dataframe
 from modeling import (evaluate_prophet_model, train_prophet_model,
                       tune_prophet_hyperparameters)
-from prophet_analysis import (PROPHET_KWARGS, compute_naive_baseline,
-                              export_baseline_forecast,
-                              export_prophet_forecast, model_to_json)
+from prophet_analysis import (
+    PROPHET_KWARGS,
+    compute_naive_baseline,
+    export_baseline_forecast,
+    export_prophet_forecast,
+    model_to_json,
+    write_summary,
+)
 
 
 def _checksum(path: Path) -> str:
@@ -140,8 +145,8 @@ def run_forecast(cfg: dict) -> None:
         scaler=None,
         transform=cfg["model"].get("transform", "log"),
     )
-    summary.to_csv(out_dir / "summary.csv", index=False)
-    horizon_table.to_csv(out_dir / "horizon_metrics.csv", index=False)
+    write_summary(summary, out_dir / "summary.csv")
+    write_summary(horizon_table, out_dir / "horizon_metrics.csv")
     diag.to_csv(out_dir / "ljung_box.csv", index=False)
     export_prophet_forecast(model, forecast, df, out_dir, scaler=None)
     export_baseline_forecast(df, out_dir)
@@ -167,7 +172,7 @@ def run_forecast(cfg: dict) -> None:
         ],
         ignore_index=True,
     )
-    metrics.to_csv(out_dir / "metrics.csv", index=False)
+    write_summary(metrics, out_dir / "metrics.csv")
 
     if cfg["model"].get("weekly_incremental") and model_to_json is not None:
         with open(base_out / "latest_model.json", "w") as f:

--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -2089,7 +2089,17 @@ def compute_naive_baseline(df: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame
         horizon_rows, columns=["horizon_days", "MAE", "RMSE", "MAPE"]
     )
 
+
     return result, metrics, horizon_df
+
+
+def write_summary(df: pd.DataFrame, path: Path) -> Path:
+    """Write a metrics DataFrame to ``path`` preserving ``NaN`` values."""
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(path, index=False, na_rep="NaN")
+    return path
 
 
 def export_baseline_forecast(df: pd.DataFrame, output_dir: Path) -> Path:
@@ -2138,7 +2148,7 @@ def export_baseline_forecast(df: pd.DataFrame, output_dir: Path) -> Path:
     else:
         # Fallback when openpyxl is unavailable - still export all data
         baseline_df.to_csv(excel_path, index=False)
-        metrics.to_csv(output_dir / "baseline_metrics.csv", index=False)
+        write_summary(metrics, output_dir / "baseline_metrics.csv")
         input_data.to_csv(output_dir / "baseline_input_data.csv", index=False)
 
     return excel_path


### PR DESCRIPTION
## Summary
- add `write_summary` helper in `prophet_analysis`
- use `write_summary` when exporting summary, horizon and metrics CSVs
- ensure baseline fallback path preserves NaN values

## Testing
- `ruff check prophet_analysis.py pipeline.py`
- `python -m pytest -q` *(fails: No module named pytest)*