### PR TITLE
Add additional unit tests

### DIFF
--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -9,3 +9,13 @@ def test_ingestion_includes_weekends():
     visits = load_time_series(Path('visitors.csv'), metric='visit')
     assert any(calls.index.dayofweek >= 5)
     assert any(visits.index.dayofweek >= 5)
+
+
+def test_load_time_series_no_header(tmp_path):
+    df = pd.read_csv('calls.csv')
+    no_header = tmp_path / 'no_header.csv'
+    df.to_csv(no_header, index=False, header=False)
+    series = load_time_series(no_header, metric='call')
+    assert not series.empty
+    expected_len = (series.index.max() - series.index.min()).days + 1
+    assert len(series) == expected_len

--- a/tests/test_metric_export.py
+++ b/tests/test_metric_export.py
@@ -1,0 +1,11 @@
+import pandas as pd
+from prophet_analysis import write_summary
+
+
+def test_write_summary_creates_file(tmp_path):
+    df = pd.DataFrame({'metric': ['MAE', 'RMSE'], 'value': [1.0, float('nan')]})
+    path = tmp_path / 'summary.csv'
+    write_summary(df, path)
+    text = path.read_text()
+    assert 'NaN' in text
+    assert text.startswith('metric,value')

--- a/tests/test_regressors.py
+++ b/tests/test_regressors.py
@@ -1,0 +1,8 @@
+import pandas as pd
+from prophet_analysis import build_flag_series
+
+
+def test_build_flag_series_basic():
+    dates = pd.date_range('2024-01-01', periods=5, freq='D')
+    flags = build_flag_series(dates, [dates[1], dates[3]])
+    assert list(flags) == [0, 1, 0, 1, 0]


### PR DESCRIPTION
## Summary
- add test for reading CSV without headers
- cover regressor flag creation helper
- test metrics CSV export function

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*