### PR TITLE
Adjust cross‑validation windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ You can modify these settings in `config.yaml` if desired.
 ## Cross-validation discipline
 
 The model is evaluated using a rolling origin cross‑validation scheme.
-The default initial window spans 365 days with a 30-day horizon and updates every 7 days. A model is accepted only if the mean absolute
+The default initial window spans 180 days with a 14-day horizon and updates every 30 days. A model is accepted only if the mean absolute
 error stays below 15% of the average call volume.
 
 ### Scaling details

--- a/config.yaml
+++ b/config.yaml
@@ -22,6 +22,6 @@ model:
   weekly_incremental: true
   uncertainty_samples: 300
 cross_validation:
-  initial: '365 days'
-  period: '7 days'
+  initial: '180 days'
+  period: '30 days'
   horizon: '14 days'

--- a/model_log.md
+++ b/model_log.md
@@ -4,5 +4,5 @@
 - Added binary regressors `is_weekend`, `is_campaign`, and `county_holiday_flag`.
 - Disabled built-in weekly seasonality and added Fourier series with order 5.
 - Tightened `changepoint_prior_scale` to 0.05 and enabled `mcmc_samples`.
-- Cross-validation defaults: initial 365d, period 7d, horizon 30d.
+- Cross-validation defaults: initial 180d, period 30d, horizon 14d.
 - Metrics for baseline and Prophet exported to `metrics.csv`.

--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -403,9 +403,9 @@ def tune_prophet_hyperparameters(prophet_df, prophet_kwargs=None):
 
             df_cv = cross_validation(
                 m,
-                initial='365 days',
+                initial='180 days',
                 period='30 days',
-                horizon='30 days',
+                horizon='14 days',
                 parallel=None
             )
             df_cv = df_cv[df_cv['ds'].dt.dayofweek < 5]
@@ -1587,7 +1587,7 @@ def analyze_prophet_components(model, forecast, output_dir):
                 plt.close()
 
 
-def cross_validate_prophet(model, df, periods=14, horizon='14 days', initial='270 days'):
+def cross_validate_prophet(model, df, periods=30, horizon='14 days', initial='180 days'):
     """Simple cross-validation for a Prophet model using a rolling origin."""
     df_cv = cross_validation(
         model,
@@ -2376,8 +2376,8 @@ def evaluate_prophet_model(
     if cv_params is None:
         cv_params = {}
 
-    initial = cv_params.get('initial', '365 days')
-    period = cv_params.get('period', '7 days')
+    initial = cv_params.get('initial', '180 days')
+    period = cv_params.get('period', '30 days')
     horizon = cv_params.get('horizon', '14 days')
     try:
         if pd.Timedelta(horizon).days > 14:


### PR DESCRIPTION
## Summary
- set the default cross-validation window to 180d initial, 30d period and 14d horizon
- document the updated schedule in the README and model log
- update helper functions and parameter tuning to use the new defaults

## Testing
- `python -m compileall -q .`
- `pytest -q` *(fails: command not found)*