### PR TITLE
Fix summary export for NaN metrics

### DIFF
--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -2104,7 +2104,20 @@ def write_summary(df: pd.DataFrame, path: Path) -> Path:
 
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
-    df.to_csv(path, index=False, na_rep="NaN")
+    try:
+        df.to_csv(path, index=False, na_rep="NaN")
+    except TypeError:
+        # Fallback for minimal DataFrame implementation without ``na_rep``
+        import csv
+        import math
+
+        with open(path, "w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(df.columns)
+            for row in df.itertuples(index=False, name=None):
+                writer.writerow(
+                    ["NaN" if isinstance(x, float) and math.isnan(x) else x for x in row]
+                )
     return path
 
 

--- a/tests/test_metric_export.py
+++ b/tests/test_metric_export.py
@@ -9,3 +9,17 @@ def test_write_summary_creates_file(tmp_path):
     text = path.read_text()
     assert 'NaN' in text
     assert text.startswith('metric,value')
+
+
+def test_write_summary_preserves_nan_columns(tmp_path):
+    df = pd.DataFrame({
+        'horizon_days': [1, 7],
+        'MAE': [0.5, 0.7],
+        'RMSE': [0.6, 0.8],
+        'MAPE': [float('nan'), float('nan')],
+    })
+    path = tmp_path / 'metrics.csv'
+    write_summary(df, path)
+    text = path.read_text()
+    assert text.splitlines()[0] == 'horizon_days,MAE,RMSE,MAPE'
+    assert text.strip().endswith('NaN')


### PR DESCRIPTION
## Summary
- handle `na_rep` fallback for stub pandas
- test to ensure columns with NaN (e.g. MAPE) are preserved

## Testing
- `python -m flake8` *(fails: No module named flake8)*
- `python -m pytest -q` *(fails: No module named pytest)*