### PR TITLE
Implement horizon escalation check

### DIFF
--- a/tests/test_horizon_escalation.py
+++ b/tests/test_horizon_escalation.py
@@ -1,0 +1,27 @@
+import logging
+import pandas as pd
+from prophet_analysis import _check_horizon_escalation
+
+
+def test_horizon_escalation_warning(caplog):
+    df = pd.DataFrame({
+        'horizon_days': [1, 14],
+        'MAE': [10.0, 13.0],
+        'RMSE': [0.0, 0.0],
+        'MAPE': [0.0, 0.0],
+    })
+    with caplog.at_level(logging.WARNING):
+        _check_horizon_escalation(df, threshold=0.2)
+    assert any('14-day horizon MAE escalates' in r.message for r in caplog.records)
+
+
+def test_horizon_escalation_ok(caplog):
+    df = pd.DataFrame({
+        'horizon_days': [1, 14],
+        'MAE': [10.0, 11.0],
+        'RMSE': [0.0, 0.0],
+        'MAPE': [0.0, 0.0],
+    })
+    with caplog.at_level(logging.WARNING):
+        _check_horizon_escalation(df, threshold=0.2)
+    assert not any('14-day horizon MAE escalates' in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- add helper to warn if 14‑day horizon error balloons compared to 1‑day horizon
- apply check after evaluation
- test escalation behaviour

## Testing
- `pytest -q` *(fails: command not found)*
- `flake8` *(fails: command not found)*