### PR TITLE
Add regression and coverage tests

### DIFF
--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1,0 +1,10 @@
+import pandas as pd
+from prophet_analysis import compute_naive_baseline
+
+
+def test_baseline_coverage_for_constant_series():
+    dates = pd.date_range('2023-01-01', periods=30, freq='D')
+    df = pd.DataFrame({'call_count': [10] * 30}, index=dates)
+    _, metrics, _ = compute_naive_baseline(df)
+    coverage = metrics.loc[metrics['metric'] == 'Coverage', 'value'].iloc[0]
+    assert coverage == 100.0

--- a/tests/test_lag_regressors.py
+++ b/tests/test_lag_regressors.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+from prophet_analysis import prepare_data
+
+
+def test_prepare_data_creates_lag_regressors():
+    df, _ = prepare_data(Path('calls.csv'), Path('visitors.csv'), Path('queries.csv'))
+    assert {'call_lag1', 'call_lag3', 'call_lag7'} <= set(df.columns)
+    assert df['call_lag1'].iloc[1] == df['call_count'].iloc[0]
+    assert df['call_lag7'].iloc[7] == df['call_count'].iloc[0]

--- a/tests/test_metric_export.py
+++ b/tests/test_metric_export.py
@@ -23,3 +23,10 @@ def test_write_summary_preserves_nan_columns(tmp_path):
     text = path.read_text()
     assert text.splitlines()[0] == 'horizon_days,MAE,RMSE,MAPE'
     assert text.strip().endswith('NaN')
+
+
+def test_write_summary_returns_path(tmp_path):
+    df = pd.DataFrame({'metric': ['MAE'], 'value': [1.0]})
+    path = tmp_path / 'out.csv'
+    returned = write_summary(df, path)
+    assert returned == path


### PR DESCRIPTION
## Summary
- add regression test for lag regressor creation
- expand metrics export tests
- add coverage computation test

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q` *(fails: No module named pytest)*