### PR TITLE
Implement configurable capacity and event windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,13 @@ hyperparameters are now tuned for a more flexible trend:
 - `uncertainty_samples=300`
 - `regressor_prior_scale=0.05`
 - `likelihood=normal`
-- `weekly_seasonality=true` to include Prophet's built-in weekly component
+- `weekly_seasonality=false` and a custom weekly component with `fourier_order=5`
+- `capacity` sets the logistic growth cap (defaults to 110% of training max)
 
-You can modify these settings in `config.yaml` if desired.
+You can modify these settings in `config.yaml` if desired. Event windows such as
+campaign dates, policy start and any explicit changepoints also live in the
+configuration file. Set `enable_mcmc: true` only when you purposely want
+Bayesian sampling, otherwise any non-zero `mcmc_samples` value is ignored.
 
 ## Cross-validation discipline
 

--- a/config.yaml
+++ b/config.yaml
@@ -15,12 +15,26 @@ model:
   transform: log
   mcmc_samples: 0
   interval_width: 0.9
-  weekly_seasonality: true
+  weekly_seasonality: false
   yearly_seasonality: auto
   daily_seasonality: false
   likelihood: poisson
   weekly_incremental: true
+  capacity: 1000
+  enable_mcmc: false
   uncertainty_samples: 300
+events:
+  policy_start: '2025-05-01'
+  campaign:
+    start: '2025-05-01'
+    end: '2025-06-02'
+  flat_period:
+    start: '2025-05-06'
+    end: '2025-05-13'
+  changepoints:
+    - '2023-11-01'
+    - '2024-04-15'
+    - '2025-04-01'
 cross_validation:
   initial: '180 days'
   period: '30 days'

--- a/tests/test_capacity.py
+++ b/tests/test_capacity.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+from holidays_calendar import get_holidays_dataframe
+from prophet_analysis import (
+    create_prophet_holidays,
+    prepare_data,
+    prepare_prophet_data,
+    train_prophet_model,
+)
+from tests.test_pipeline_alignment import DummyProphet
+
+
+def _setup():
+    df, regs = prepare_data(Path('calls.csv'), Path('visitors.csv'), Path('queries.csv'))
+    prophet_df = prepare_prophet_data(df)
+    holiday_df = get_holidays_dataframe()
+    mask = (
+        (holiday_df['event'] == 'county_holiday')
+        & (holiday_df['date'] >= df.index.min())
+        & (holiday_df['date'] <= df.index.max())
+    )
+    holidays = create_prophet_holidays(
+        holiday_df.loc[mask, 'date'],
+        pd.date_range(df.index.min(), df.index.max(), freq='MS'),
+        closure_dates=[],
+        press_release_dates=[],
+    )
+    return prophet_df, holidays, regs
+
+
+def test_capacity_from_config():
+    prophet_df, holidays, regs = _setup()
+    with patch('prophet_analysis.Prophet', DummyProphet):
+        _, _, future = train_prophet_model(
+            prophet_df,
+            holidays,
+            regs,
+            future_periods=2,
+            model_params={'capacity': 500, 'growth': 'logistic'},
+        )
+    assert future['cap'].iloc[0] == 500
+
+
+def test_capacity_auto():
+    prophet_df, holidays, regs = _setup()
+    expected = float(prophet_df['y'].max() * 1.1)
+    with patch('prophet_analysis.Prophet', DummyProphet):
+        _, _, future = train_prophet_model(
+            prophet_df,
+            holidays,
+            regs,
+            future_periods=2,
+        )
+    assert future['cap'].iloc[0] == pytest.approx(expected)
+

--- a/tests/test_feature_alignment.py
+++ b/tests/test_feature_alignment.py
@@ -12,9 +12,7 @@ def dropping_cols(df, threshold=0.9, return_dropped=False):
     dropped = [
         c
         for c in [
-            'holiday_flag',
             'is_campaign',
-            'campaign_May2025',
             'is_weekend',
             'press_release_flag',
             'post_policy',


### PR DESCRIPTION
## Summary
- allow customizing Prophet kwargs centrally
- move event windows and changepoints to config
- compute logistic capacity dynamically with override
- disable Prophet weekly seasonality and add explicit weekly component
- drop duplicate flags and update tests
- stop automatic model log updates
- add unit test for capacity logic

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*
- `flake8` *(fails: command not found)*