### PR TITLE
Fix CPS halving loop

### DIFF
--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -2504,8 +2504,11 @@ def evaluate_prophet_model(
     history = model.history.copy()
     reg_info = model.extra_regressors.copy()
     df_cv = None
+    lb_first = None
     lb_p = 0.0
     attempts = 0
+    current_scale = model.changepoint_prior_scale
+    orig_model = model
     while True:
         df_cv = cross_validation(
             model,
@@ -2517,26 +2520,38 @@ def evaluate_prophet_model(
         df_cv = df_cv[df_cv['ds'].dt.dayofweek < 5]
         residuals = df_cv['y'] - df_cv['yhat']
         lb = acorr_ljungbox(residuals, lags=14, return_df=True)
-        lb_p = lb['lb_pvalue'].min()
-        if lb_p > 0.05 or attempts >= 2:
+        if lb_first is None:
+            lb_first = lb.copy()
+            lb_p = lb['lb_pvalue'].min()
+            if 0.2 <= lb_p <= 0.8:
+                break
+        else:
+            lb_p = lb['lb_pvalue'].min()
+        if lb_p > 0.05 or attempts >= 1:
             break
         attempts += 1
-        new_scale = model.changepoint_prior_scale * 0.5
-        logger.info("Autocorrelation detected, refitting with changepoint_prior_scale=%s", new_scale)
+        current_scale *= 0.5
+        logger.info(
+            "Autocorrelation detected, refitting with changepoint_prior_scale=%s",
+            current_scale,
+        )
         model = Prophet(
             growth=model.growth,
             interval_width=model.interval_width,
             seasonality_mode=model.seasonality_mode,
-            changepoint_prior_scale=new_scale,
+            changepoint_prior_scale=current_scale,
             n_changepoints=model.n_changepoints,
             holidays=model.holidays,
             **PROPHET_KWARGS,
         )
         for name, info in reg_info.items():
-            allowed = {k: v for k, v in info.items() if k in {'prior_scale', 'mode', 'standardize'}}
+            allowed = {
+                k: v for k, v in info.items() if k in {"prior_scale", "mode", "standardize"}
+            }
             model.add_regressor(name, **allowed)
         _ensure_tbb_on_path()
         _fit_prophet_with_fallback(model, history)
+    orig_model.changepoint_prior_scale = current_scale
 
     if transform is None and log_transform:
         transform = "log"
@@ -2680,10 +2695,11 @@ def evaluate_prophet_model(
 
     _check_horizon_escalation(horizon_table)
 
+    lb_diag = lb_first if lb_first is not None else lb
     diag = pd.DataFrame({
-        'lag': lb.index,
-        'lb_stat': lb['lb_stat'],
-        'lb_pvalue': lb['lb_pvalue']
+        'lag': lb_diag.index,
+        'lb_stat': lb_diag['lb_stat'],
+        'lb_pvalue': lb_diag['lb_pvalue']
     })
 
     mean_calls = df_cv['y'].mean()

--- a/tests/test_autocorr_loop.py
+++ b/tests/test_autocorr_loop.py
@@ -1,0 +1,50 @@
+import pandas as pd
+from unittest.mock import patch
+
+from prophet_analysis import evaluate_prophet_model
+from tests.test_pipeline_alignment import DummyProphet
+
+
+def _stub_cv(*_args, **_kwargs):
+    return pd.DataFrame({
+        'ds': pd.date_range('2023-01-01', periods=3, freq='D'),
+        'y': [1.0, 2.0, 3.0],
+        'yhat': [1.0, 2.0, 3.0],
+    })
+
+
+def _lb_mid(residuals, lags=14, return_df=True):
+    return pd.DataFrame({'lb_stat': [0.0] * lags, 'lb_pvalue': [0.5] * lags})
+
+
+def test_stop_on_mid_range_pvalue():
+    model = DummyProphet()
+    prophet_df = pd.DataFrame({'ds': pd.date_range('2023-01-01', periods=3), 'y': [1, 2, 3]})
+    with patch('prophet_analysis.cross_validation', side_effect=_stub_cv) as cv_mock, \
+         patch('prophet_analysis.acorr_ljungbox', side_effect=_lb_mid), \
+         patch('prophet_analysis._fit_prophet_with_fallback'), \
+         patch('prophet_analysis._ensure_tbb_on_path'):
+        evaluate_prophet_model(model, prophet_df)
+        assert cv_mock.call_count == 1
+        assert model.changepoint_prior_scale == 0.2
+
+
+def test_changepoint_scale_persist_after_refit():
+    model = DummyProphet(changepoint_prior_scale=0.4)
+    prophet_df = pd.DataFrame({'ds': pd.date_range('2023-01-01', periods=3), 'y': [1, 2, 3]})
+
+    def lb_side_effect(residuals, lags=14, return_df=True):
+        if lb_side_effect.calls == 0:
+            lb_side_effect.calls += 1
+            return pd.DataFrame({'lb_stat': [1.0] * lags, 'lb_pvalue': [0.01] * lags})
+        return pd.DataFrame({'lb_stat': [0.0] * lags, 'lb_pvalue': [0.5] * lags})
+
+    lb_side_effect.calls = 0
+
+    with patch('prophet_analysis.cross_validation', side_effect=_stub_cv) as cv_mock, \
+         patch('prophet_analysis.acorr_ljungbox', side_effect=lb_side_effect), \
+         patch('prophet_analysis._fit_prophet_with_fallback'), \
+         patch('prophet_analysis._ensure_tbb_on_path'):
+        evaluate_prophet_model(model, prophet_df)
+        assert cv_mock.call_count == 2
+        assert model.changepoint_prior_scale == 0.2


### PR DESCRIPTION
## Summary
- stop refitting when Ljung-Box p-values fall in the range [0.2, 0.8]
- persist the final changepoint prior scale in the original model
- keep the first Ljung-Box results for diagnostics
- add unit tests covering new behavior

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*