### PR TITLE
Replace MAPE with Poisson deviance

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ The results, including forecasts and plots, will be saved in the specified outpu
 The exported Excel report (`prophet_call_predictions_v3.xlsx`) now includes
 predictions for the previous 14 business days along with a forecast for the next
 business day. A seasonal naive baseline forecast using the call volume from the
-same weekday in the prior week and the corresponding MAE, RMSE and MAPE metrics
-are also included. The report additionally lists the predicted call volume for
+same weekday in the prior week and the corresponding MAE, RMSE and Poisson
+deviance metrics are also included. The report additionally lists the predicted call volume for
 the upcoming business day in a dedicated sheet.
 
 ## Model specification

--- a/tests/test_horizon_escalation.py
+++ b/tests/test_horizon_escalation.py
@@ -8,7 +8,6 @@ def test_horizon_escalation_warning(caplog):
         'horizon_days': [1, 14],
         'MAE': [10.0, 13.0],
         'RMSE': [0.0, 0.0],
-        'MAPE': [0.0, 0.0],
     })
     with caplog.at_level(logging.WARNING):
         _check_horizon_escalation(df, threshold=0.2)
@@ -20,7 +19,6 @@ def test_horizon_escalation_ok(caplog):
         'horizon_days': [1, 14],
         'MAE': [10.0, 11.0],
         'RMSE': [0.0, 0.0],
-        'MAPE': [0.0, 0.0],
     })
     with caplog.at_level(logging.WARNING):
         _check_horizon_escalation(df, threshold=0.2)

--- a/tests/test_metric_export.py
+++ b/tests/test_metric_export.py
@@ -16,12 +16,12 @@ def test_write_summary_preserves_nan_columns(tmp_path):
         'horizon_days': [1, 7],
         'MAE': [0.5, 0.7],
         'RMSE': [0.6, 0.8],
-        'MAPE': [float('nan'), float('nan')],
+        'Poisson': [float('nan'), float('nan')],
     })
     path = tmp_path / 'metrics.csv'
     write_summary(df, path)
     text = path.read_text()
-    assert text.splitlines()[0] == 'horizon_days,MAE,RMSE,MAPE'
+    assert text.splitlines()[0] == 'horizon_days,MAE,RMSE,Poisson'
     assert text.strip().endswith('NaN')
 
 
@@ -32,7 +32,7 @@ def test_write_summary_returns_path(tmp_path):
     assert returned == path
 
 
-def test_write_summary_computes_mape(tmp_path):
+def test_write_summary_computes_poisson(tmp_path):
     df = pd.DataFrame({
         'actual': [0, 0],
         'predicted': [1, 2]
@@ -40,4 +40,4 @@ def test_write_summary_computes_mape(tmp_path):
     path = tmp_path / 'preds.csv'
     write_summary(df, path)
     text = path.read_text()
-    assert 'MAPE' in text.splitlines()[0]
+    assert 'Poisson' in text.splitlines()[0]


### PR DESCRIPTION
## Summary
- support Poisson deviance metric in prophet analysis
- drop MAPE in baseline and cross-validation metrics
- update README and tests for new metric

## Testing
- `python -m py_compile prophet_analysis.py tests/test_metric_export.py tests/test_horizon_escalation.py`
- `pytest -q` *(fails: command not found)*