### PR TITLE
Fix missing Prophet import error

### DIFF
--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -1067,6 +1067,9 @@ def train_prophet_model(
     """
     logger = logging.getLogger(__name__)
     logger.info("Training Prophet model")
+
+    if Prophet is None:
+        raise ImportError("prophet package is required for forecasting features")
     
     # Initialize Prophet model with optional tuned parameters
 


### PR DESCRIPTION
## Summary
- raise `ImportError` in `train_prophet_model` when Prophet isn't available

## Testing
- `pip install pytest` *(fails: Could not find a version that satisfies the requirement)*
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement)*