### PR TITLE
Improve run_forecast interpreter detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ export USE_STUB_LIBS=1  # Unix
 
 This variable is already set in the provided `run_forecast.bat` script, which
 honors a `PYTHON` environment variable so you can choose a custom interpreter.
-If it
+If no interpreter is specified, the batch file automatically uses a
+`.venv\Scripts\python.exe` next to the repository when available. If it
 does not run when double-clicked, ensure it uses Windows
 line endings (CRLF). Some Git tools may check out the repository with Unix
 line endings, which can cause `cmd.exe` to ignore the script. You can convert

--- a/run_forecast.bat
+++ b/run_forecast.bat
@@ -1,12 +1,24 @@
 @echo off
 cd /d "%~dp0"
 
+REM Use stub libraries for unit testing by default
+set "USE_STUB_LIBS=1"
+
 REM Run the full forecasting pipeline. Provide a config path as the first
 REM argument or default to "config.yaml".
-
 set "CONFIG=%1"
 if "%CONFIG%"=="" set "CONFIG=config.yaml"
-if "%PYTHON%"=="" set "PYTHON=python"
+
+REM Determine which Python interpreter to use. If "PYTHON" is set we honor
+REM it, otherwise prefer a local virtual environment before falling back to
+REM the system "python".
+if "%PYTHON%"=="" (
+    if exist ".venv\Scripts\python.exe" (
+        set "PYTHON=.venv\Scripts\python.exe"
+    ) else (
+        set "PYTHON=python"
+    )
+)
 
 %PYTHON% pipeline.py "%CONFIG%"
 


### PR DESCRIPTION
## Summary
- handle `.venv` in run_forecast.bat so the correct Python is used
- clarify README about auto-detected virtual environments

## Testing
- `pytest -q` *(fails: No module named pytest)*
- `python3 -m pytest -q` *(fails: No module named pytest)*