### PR TITLE
Insert Prophet import check into pipeline

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -1,3 +1,6 @@
+from prophet import Prophet
+print("Explicit Prophet import successful:", Prophet)
+
 import os
 import sys
 from pathlib import Path


### PR DESCRIPTION
## Summary
- verify Prophet can be imported by printing its module from `pipeline.py`

## Testing
- `flake8 --version` *(fails: command not found)*
- `pylint --version` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*