### PR TITLE
Fix index handling in prepare_data

### DIFF
--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -928,8 +928,8 @@ def prepare_data(
 
     # Remove any remaining NaNs before returning the feature matrix
     mask = df.dropna().index
-    df = df.loc[mask].reset_index(drop=True)
-    regressors = regressors.loc[mask].reset_index(drop=True)
+    df = df.loc[mask]
+    regressors = regressors.loc[mask]
 
     return df, regressors
 


### PR DESCRIPTION
## Summary
- keep original DatetimeIndex when returning data from `prepare_data`

## Testing
- `ruff check .` *(fails: many existing lint errors)*
- `pytest -q` *(fails: pytest not installed)*