### PR TITLE
Fix cross_validation shadowing

### DIFF
--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -92,13 +92,14 @@ def _get_prophet():
 # Import Prophet
 try:
     from prophet import Prophet
-    from prophet.diagnostics import cross_validation, performance_metrics
+    from prophet.diagnostics import cross_validation as _cross_validation, performance_metrics
     from prophet.plot import plot_cross_validation_metric
     from prophet.models import StanBackendCmdStan
+    cross_validation_func = _cross_validation
     _HAVE_PROPHET = True
 except Exception:  # pragma: no cover - optional dependency may be missing
     Prophet = None
-    cross_validation = None
+    cross_validation_func = None
     performance_metrics = None
     plot_cross_validation_metric = None
 
@@ -485,7 +486,7 @@ def tune_prophet_hyperparameters(prophet_df, prophet_kwargs=None):
             _ensure_tbb_on_path()
             _fit_prophet_with_fallback(m, df_copy)
 
-            df_cv = cross_validation(
+            df_cv = cross_validation_func(
                 m,
                 initial='180 days',
                 period='30 days',
@@ -1870,7 +1871,7 @@ def analyze_prophet_components(model, forecast, output_dir):
 
 def cross_validate_prophet(model, df, periods=30, horizon='14 days', initial='180 days'):
     """Simple cross-validation for a Prophet model using a rolling origin."""
-    df_cv = cross_validation(
+    df_cv = cross_validation_func(
         model,
         initial=initial,
         period=f'{periods} days',
@@ -2691,7 +2692,7 @@ def evaluate_prophet_model(
     current_scale = model.changepoint_prior_scale
     orig_model = model
     while True:
-        df_cv = cross_validation(
+        df_cv = cross_validation_func(
             model,
             initial=initial,
             period=period,

--- a/tests/test_autocorr_loop.py
+++ b/tests/test_autocorr_loop.py
@@ -20,7 +20,7 @@ def _lb_mid(residuals, lags=14, return_df=True):
 def test_stop_on_mid_range_pvalue():
     model = DummyProphet()
     prophet_df = pd.DataFrame({'ds': pd.date_range('2023-01-01', periods=3), 'y': [1, 2, 3]})
-    with patch('prophet_analysis.cross_validation', side_effect=_stub_cv) as cv_mock, \
+    with patch('prophet_analysis.cross_validation_func', side_effect=_stub_cv) as cv_mock, \
          patch('prophet_analysis.acorr_ljungbox', side_effect=_lb_mid), \
          patch('prophet_analysis._fit_prophet_with_fallback'), \
          patch('prophet_analysis._ensure_tbb_on_path'):
@@ -41,7 +41,7 @@ def test_changepoint_scale_persist_after_refit():
 
     lb_side_effect.calls = 0
 
-    with patch('prophet_analysis.cross_validation', side_effect=_stub_cv) as cv_mock, \
+    with patch('prophet_analysis.cross_validation_func', side_effect=_stub_cv) as cv_mock, \
          patch('prophet_analysis.acorr_ljungbox', side_effect=lb_side_effect), \
          patch('prophet_analysis._fit_prophet_with_fallback'), \
          patch('prophet_analysis._ensure_tbb_on_path'):


### PR DESCRIPTION
## Summary
- avoid clobbering the `cross_validation` import by renaming to `cross_validation_func`
- update references and tests accordingly

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*