### PR TITLE
Fix cross_validation shadowing

### DIFF
--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -99,7 +99,6 @@ try:
     _HAVE_PROPHET = True
 except Exception:  # pragma: no cover - optional dependency may be missing
     Prophet = None
-    cross_validation = None
     cross_validation_func = None
     performance_metrics = None
     plot_cross_validation_metric = None


### PR DESCRIPTION
## Summary
- remove assignment that overwrote `cross_validation`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*