### PR TITLE
Fix Windows multiprocessing issues

### DIFF
--- a/data_pipeline.py
+++ b/data_pipeline.py
@@ -8,6 +8,16 @@ holidays, notice-of-value mail-outs and other campaign periods. The result is
 written to a CSV file that can be used for modeling or further analysis.
 """
 
+# ruff: noqa: E402
+import os
+for var in (
+    "OMP_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+):
+    os.environ[var] = "1"
+
 import argparse
 from pathlib import Path
 
@@ -22,6 +32,10 @@ def main(calls: Path, visitors: Path, queries: Path, out_path: Path) -> None:
 
 
 if __name__ == "__main__":
+    import multiprocessing as mp
+
+    mp.freeze_support()
+
     parser = argparse.ArgumentParser(
         description="Generate engineered feature CSV for forecasting"
     )

--- a/holidays_calendar.py
+++ b/holidays_calendar.py
@@ -1,4 +1,14 @@
+# ruff: noqa: E402
 from datetime import date
+
+import os
+for var in (
+    "OMP_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+):
+    os.environ[var] = "1"
 
 import pandas as pd
 
@@ -113,5 +123,9 @@ def get_holidays_dataframe() -> pd.DataFrame:
 
 
 if __name__ == "__main__":
+    import multiprocessing as mp
+
+    mp.freeze_support()
+
     df = get_holidays_dataframe()
     print(df.head())

--- a/naive_forecast.py
+++ b/naive_forecast.py
@@ -8,51 +8,59 @@ import csv
 from datetime import datetime
 from math import sqrt
 
-# Load call data
-rows = []
-with open('calls.csv') as f:
-    reader = csv.reader(f)
-    for row in reader:
-        if not row:
-            continue
-        date_str, value_str = row
-        parsed = None
-        for fmt in ("%m/%d/%Y", "%m/%d/%y"):
-            try:
-                parsed = datetime.strptime(date_str.strip(), fmt)
-                break
-            except ValueError:
+
+def main() -> None:
+    rows = []
+    with open("calls.csv") as f:
+        reader = csv.reader(f)
+        for row in reader:
+            if not row:
                 continue
-        if not parsed:
-            # skip header or malformed lines
-            continue
-        date = parsed
-        rows.append((date.strftime('%Y-%m-%d'), float(value_str)))
+            date_str, value_str = row
+            parsed = None
+            for fmt in ("%m/%d/%Y", "%m/%d/%y"):
+                try:
+                    parsed = datetime.strptime(date_str.strip(), fmt)
+                    break
+                except ValueError:
+                    continue
+            if not parsed:
+                # skip header or malformed lines
+                continue
+            date = parsed
+            rows.append((date.strftime("%Y-%m-%d"), float(value_str)))
 
-# Ensure data is sorted by date
-rows.sort(key=lambda x: x[0])
+    # Ensure data is sorted by date
+    rows.sort(key=lambda x: x[0])
 
-# Need one week of extra history for the seasonal naive baseline
-recent = rows[-21:]
+    # Need one week of extra history for the seasonal naive baseline
+    recent = rows[-21:]
 
-preds = []
-acts = []
-dates = []
-for i in range(7, len(recent)):
-    pred = recent[i - 7][1]
-    actual = recent[i][1]
-    preds.append(pred)
-    acts.append(actual)
-    dates.append(recent[i][0])
+    preds = []
+    acts = []
+    dates = []
+    for i in range(7, len(recent)):
+        pred = recent[i - 7][1]
+        actual = recent[i][1]
+        preds.append(pred)
+        acts.append(actual)
+        dates.append(recent[i][0])
 
-# Compute metrics
-n = len(preds)
-mae = sum(abs(a - p) for a, p in zip(acts, preds)) / n
-rmse = sqrt(sum((a - p) ** 2 for a, p in zip(acts, preds)) / n)
+    # Compute metrics
+    n = len(preds)
+    mae = sum(abs(a - p) for a, p in zip(acts, preds)) / n
+    rmse = sqrt(sum((a - p) ** 2 for a, p in zip(acts, preds)) / n)
 
-print("date,predicted,actual")
-for d, p, a in zip(dates, preds, acts):
-    print(f"{d},{p},{a}")
+    print("date,predicted,actual")
+    for d, p, a in zip(dates, preds, acts):
+        print(f"{d},{p},{a}")
 
-print(f"MAE,{mae:.2f}")
-print(f"RMSE,{rmse:.2f}")
+    print(f"MAE,{mae:.2f}")
+    print(f"RMSE,{rmse:.2f}")
+
+
+if __name__ == "__main__":
+    import multiprocessing as mp
+
+    mp.freeze_support()
+    main()

--- a/pipeline.py
+++ b/pipeline.py
@@ -1,7 +1,16 @@
+# ruff: noqa: E402
+import os
+for var in (
+    "OMP_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+):
+    os.environ[var] = "1"
+
 from prophet import Prophet
 print("Explicit Prophet import successful:", Prophet)
 
-import os
 import sys
 from pathlib import Path
 
@@ -225,6 +234,10 @@ def pipeline(config_path: Path) -> None:
 
 
 if __name__ == "__main__":
+    import multiprocessing as mp
+
+    mp.freeze_support()
+
     import argparse
 
     p = argparse.ArgumentParser(description="Run forecast pipeline")

--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -16,9 +16,17 @@ Example usage::
         --handle-outliers winsorize --use-transformation false --skip-feature-importance
 """
 
+# ruff: noqa: E402
 from __future__ import annotations
 
 import os
+for var in (
+    "OMP_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+):
+    os.environ[var] = "1"
 import sys
 
 # By default the real third-party packages are imported. Set ``USE_STUB_LIBS=1``
@@ -486,7 +494,7 @@ def tune_prophet_hyperparameters(prophet_df, prophet_kwargs=None):
                 initial='180 days',
                 period='30 days',
                 horizon='14 days',
-                parallel="processes"
+                parallel="threads"
             )
             df_cv = df_cv[df_cv['ds'].dt.dayofweek < 5]
             df_p = performance_metrics(df_cv, rolling_window=1)
@@ -1861,7 +1869,7 @@ def cross_validate_prophet(model, df, periods=30, horizon='14 days', initial='18
         initial=initial,
         period=f'{periods} days',
         horizon=horizon,
-        parallel="processes",
+        parallel="threads",
     )
     df_p = performance_metrics(df_cv)
     return df_p['rmse'].mean()
@@ -2682,7 +2690,7 @@ def evaluate_prophet_model(
             initial=initial,
             period=period,
             horizon=horizon,
-            parallel="processes",
+            parallel="threads",
         )
         df_cv = df_cv[df_cv['ds'].dt.dayofweek < 5]
         residuals = df_cv['y'] - df_cv['yhat']
@@ -2971,4 +2979,7 @@ def main(argv=None):
 
     pipeline.run_forecast(cfg)
 if __name__ == "__main__":
+    import multiprocessing as mp
+
+    mp.freeze_support()
     main()


### PR DESCRIPTION
## Summary
- guard script entry points with `freeze_support`
- ensure BLAS threads are limited and disable process-based prophet CV
- refactor naive_forecast into a `main()` function

## Testing
- `ruff check .` *(fails: F401, F841, E741, F821)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*