### PR TITLE
Add hard import for performance_metrics

### DIFF
--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -18,6 +18,7 @@ Example usage::
 
 # ruff: noqa: E402
 from __future__ import annotations
+from prophet.diagnostics import performance_metrics  # hard import
 
 import os
 for var in (
@@ -100,13 +101,12 @@ def _get_prophet():
 # Import Prophet
 try:
     from prophet import Prophet
-    from prophet.diagnostics import cross_validation, performance_metrics
+    from prophet.diagnostics import cross_validation
     from prophet.plot import plot_cross_validation_metric
     from prophet.models import StanBackendCmdStan
     _HAVE_PROPHET = True
 except Exception:  # pragma: no cover - optional dependency may be missing
     Prophet = None
-    performance_metrics = None
     plot_cross_validation_metric = None
 
     class _DummyBackend:


### PR DESCRIPTION
## Summary
- import `performance_metrics` directly from `prophet.diagnostics`
- drop fallback that set `performance_metrics = None`

## Testing
- `ruff check .` *(fails: unused imports etc.)*
- `pytest -q` *(fails: pandas not installed)*