### PR TITLE
Fix undefined cross_validation_func on missing Prophet

### DIFF
--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -118,6 +118,7 @@ except Exception:  # pragma: no cover - optional dependency may be missing
 
     StanBackendCmdStan = _DummyBackend  # type: ignore
 
+    cross_validation_func = None
     _HAVE_PROPHET = False
 
 # Handle seaborn import safely


### PR DESCRIPTION
## Summary
- avoid NameError when Prophet is missing by defining `cross_validation_func = None`

## Testing
- `ruff check prophet_analysis.py`
- `USE_STUB_LIBS=1 pytest tests/test_autocorr_loop.py::test_autocorr_loop -q` *(fails: ModuleNotFoundError: No module named 'pandas')*