### PR TITLE
Improve cross-validation error handling

### DIFF
--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -2685,6 +2685,9 @@ def evaluate_prophet_model(
     )
 
 
+    if cross_validation_func is None:
+        raise ImportError("prophet package is required for cross validation")
+
     history = model.history.copy()
     reg_info = model.extra_regressors.copy()
     df_cv = None


### PR DESCRIPTION
## Summary
- raise `ImportError` when Prophet cross-validation function is unavailable

## Testing
- `ruff check prophet_analysis.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*