### PR TITLE
Fix CLI pipeline import

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -12,6 +12,10 @@ from prophet import Prophet
 print("Explicit Prophet import successful:", Prophet)
 
 import sys
+if __name__ == "__main__":
+    # Expose this module as ``pipeline`` when executed as a script so that
+    # helper modules can import it without errors.
+    sys.modules.setdefault("pipeline", sys.modules[__name__])
 from pathlib import Path
 
 # By default the real third-party packages are used. Set ``USE_STUB_LIBS=1``

--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -69,7 +69,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 import pandas as pd
 import statsmodels
-import pipeline
 from sklearn.feature_selection import mutual_info_regression
 from sklearn.metrics import mean_absolute_error, mean_squared_error
 
@@ -2998,6 +2997,7 @@ def main(argv=None):
     )
     args = parser.parse_args(argv)
 
+    import pipeline
     cfg = pipeline.load_config(Path("config.yaml"))
     cfg["data"]["calls"] = str(args.call_data)
     cfg["data"]["visitors"] = str(args.visitor_data)


### PR DESCRIPTION
## Summary
- expose module as `pipeline` when run as a script
- import `pipeline` lazily in `prophet_analysis`

## Testing
- `ruff check pipeline.py prophet_analysis.py`
- `PYTHONPATH=. USE_STUB_LIBS=1 pytest -q tests/test_ingestion.py`
