### PR TITLE
Fix stub shadowing for Prophet imports

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -8,9 +8,6 @@ for var in (
 ):
     os.environ[var] = "1"
 
-from prophet import Prophet
-print("Explicit Prophet import successful:", Prophet)
-
 import sys
 if __name__ == "__main__":
     # Expose this module as ``pipeline`` when executed as a script so that
@@ -29,6 +26,9 @@ if not _USE_STUB_LIBS:
     # installed packages.
     sys.path = [p for p in sys.path if os.path.abspath(p or os.getcwd()) != _THIS_DIR]
     sys.path.append(_THIS_DIR)
+
+from prophet import Prophet
+print("Explicit Prophet import successful:", Prophet)
 try:
     from ruamel.yaml import YAML  # type: ignore
 except ModuleNotFoundError:

--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -18,8 +18,6 @@ Example usage::
 
 # ruff: noqa: E402
 from __future__ import annotations
-from prophet.diagnostics import cross_validation as _cross_validation
-from prophet.diagnostics import performance_metrics as _performance_metrics
 
 import os
 for var in (
@@ -42,6 +40,9 @@ if not _USE_STUB_LIBS:
         for p in sys.path
         if os.path.abspath(p or os.getcwd()) != _THIS_DIR
     ]
+
+from prophet.diagnostics import cross_validation as _cross_validation
+from prophet.diagnostics import performance_metrics as _performance_metrics
 import matplotlib
 
 if not hasattr(matplotlib, "use"):


### PR DESCRIPTION
## Summary
- ensure sys.path is adjusted before importing Prophet classes
- reorder Prophet diagnostics import in `prophet_analysis.py`

## Testing
- `ruff check .` *(fails: F401, E741)*
- `pytest -q` *(no tests ran)*