### PR TITLE
Fix Prophet diagnostics imports

### DIFF
--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -41,7 +41,7 @@ if not _USE_STUB_LIBS:
         if os.path.abspath(p or os.getcwd()) != _THIS_DIR
     ]
 
-from prophet.diagnostics import cross_validation as _cross_validation
+from prophet.diagnostics import cross_validation, performance_metrics
 import matplotlib
 
 if not hasattr(matplotlib, "use"):
@@ -100,8 +100,7 @@ try:
     from prophet.plot import plot_cross_validation_metric
     from prophet.models import StanBackendCmdStan
     _HAVE_PROPHET = True
-    cross_validation = None
-    cross_validation_func = _cross_validation
+    cross_validation_func = cross_validation
 except Exception:  # pragma: no cover - optional dependency may be missing
     Prophet = None
     plot_cross_validation_metric = None
@@ -113,14 +112,6 @@ except Exception:  # pragma: no cover - optional dependency may be missing
     StanBackendCmdStan = _DummyBackend  # type: ignore
     cross_validation_func = None
     _HAVE_PROPHET = False
-
-def performance_metrics(*args, **kwargs):
-    """Wrapper around ``prophet.diagnostics.performance_metrics`` with lazy import."""
-    try:
-        from prophet.diagnostics import performance_metrics as _internal_metrics
-    except ImportError:
-        raise ImportError("prophet package is required for cross validation")
-    return _internal_metrics(*args, **kwargs)
 
 # Handle seaborn import safely
 try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ numpy==1.23.5
 matplotlib==3.7.1
 seaborn==0.12.2
 scikit-learn==1.3.1
-prophet==1.1.5
+prophet>=1.1.7
 openpyxl==3.1.2
 
 ruamel.yaml==0.17.32


### PR DESCRIPTION
## Summary
- pin Prophet to the newer 1.1.7 release
- import diagnostics helpers from `prophet.diagnostics`
- drop obsolete wrapper around `performance_metrics`

## Testing
- `pytest -q` *(tests skipped: pandas stub)*

------
https://chatgpt.com/codex/tasks/task_e_683dc43bc0f0832e8dc5fbe90427b02f