### PR TITLE
Fix custom Stan backend for Prophet 1.1.7

### DIFF
--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -95,7 +95,7 @@ def _get_prophet():
 
 
 # Import Prophet
-from prophet.models import StanBackendCmdStan
+from prophet.models import StanBackendCmdStanPy
 
 _HAVE_PROPHET = True
 cross_validation_func = cross_validation
@@ -1159,7 +1159,7 @@ def train_prophet_model(
         try:
             with open(custom_model_path, "rb") as f:
                 compiled_model = pickle.load(f)
-            backend = StanBackendCmdStan(model=compiled_model)
+            backend = StanBackendCmdStanPy(model=compiled_model)
         except Exception as e:  # pragma: no cover - prophet may be missing
             logger.warning(f"Could not create custom Stan backend: {e}")
 

--- a/prophet_src_backup/models/__init__.py
+++ b/prophet_src_backup/models/__init__.py
@@ -1,2 +1,5 @@
-class StanBackendCmdStan:
+class StanBackendCmdStanPy:
     pass
+
+# Older name retained for backward compatibility
+StanBackendCmdStan = StanBackendCmdStanPy


### PR DESCRIPTION
## Summary
- support Prophet 1.1.7 by switching to `StanBackendCmdStanPy`
- keep backwards compatibility in stub model

## Testing
- `ruff check prophet_analysis.py prophet_src_backup/models/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683dccd2e978832ea13f4c81b84ba67a