### PR TITLE
Fix naive baseline output unpacking

### DIFF
--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -2537,7 +2537,7 @@ def export_prophet_forecast(model, forecast, df, output_dir, scaler=None):
             prophet_metrics.to_excel(writer, sheet_name='Prophet Metrics', index=False)
 
             # Naive baseline forecast and metrics
-            naive_df, naive_metrics = compute_naive_baseline(df)
+            naive_df, naive_metrics, _naive_horizon = compute_naive_baseline(df)
             naive_df.to_excel(writer, sheet_name='Naive 14-Day Forecast', index=False)
             naive_metrics.to_excel(writer, sheet_name='Naive Metrics', index=False)
 


### PR DESCRIPTION
## Summary
- grab the horizon output from `compute_naive_baseline`

## Testing
- `USE_STUB_LIBS=1 PYTHONPATH=. pytest tests/test_autocorr_loop.py -q` *(fails: ModuleNotFoundError: No module named 'prophet')*
- `python pipeline.py config.yaml` *(fails: ModuleNotFoundError: No module named 'prophet')*

------
https://chatgpt.com/codex/tasks/task_e_683dd087a76c832e89782634d287528e