### PR TITLE
Fix baseline unpack contract

### DIFF
--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -2537,7 +2537,8 @@ def export_prophet_forecast(model, forecast, df, output_dir, scaler=None):
             prophet_metrics.to_excel(writer, sheet_name='Prophet Metrics', index=False)
 
             # Naive baseline forecast and metrics
-            naive_df, naive_metrics, _naive_horizon = compute_naive_baseline(df)
+            result = compute_naive_baseline(df)
+            naive_df, naive_metrics = result[:2]
             naive_df.to_excel(writer, sheet_name='Naive 14-Day Forecast', index=False)
             naive_metrics.to_excel(writer, sheet_name='Naive Metrics', index=False)
 


### PR DESCRIPTION
## Notes
- Revised export_prophet_forecast to handle three-value output from `compute_naive_baseline` without raising a ValueError.
- Ran ruff and pytest (no tests executed due to stub libraries).

## Summary
- Use slicing to extract forecast and metrics from `compute_naive_baseline`.


------
https://chatgpt.com/codex/tasks/task_e_683df6382bf0832e9d5eefdeeaf98d38