### PR TITLE
Add dependencies for interactive plotting and cmdstan build fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Core dependencies
 pandas>=2.0
 numpy==1.23.5
-matplotlib==3.7.1
+matplotlib[tk]==3.7.1
 seaborn==0.12.2
 scikit-learn==1.3.1
 prophet>=1.1.7
@@ -9,3 +9,5 @@ openpyxl==3.1.2
 
 ruamel.yaml==0.17.32
 statsmodels>=0.14.2
+plotly==5.22.0
+kaleido

--- a/run_forecast.bat
+++ b/run_forecast.bat
@@ -23,6 +23,12 @@ if not defined PYTHON (
 REM ----- repo root -----
 pushd "%~dp0" || exit /b 2
 
+REM ----- cmdstanpy temp directory -----
+if not exist "C:\cmdstan_tmp" (
+    mkdir C:\cmdstan_tmp
+)
+set "CMDSTANPY_TMPDIR=C:\cmdstan_tmp"
+
 REM ----- venv -----
 if not exist ".venv\Scripts\python.exe" (
     "%PYTHON%" -m venv .venv || exit /b 3


### PR DESCRIPTION
## Summary
- install Plotly and Kaleido for visualization
- include Tk-enabled Matplotlib
- configure a temporary directory for cmdstanpy builds

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'prophet')*

------
https://chatgpt.com/codex/tasks/task_e_683dfcd4df6c832e8aef46a4b445de0d