### PR TITLE
Fix double exponentiation during export

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -200,7 +200,7 @@ def run_forecast(cfg: dict) -> None:
         model,
         prophet_df,
         cv_params=cv_params,
-        forecast=forecast,
+        forecast=None,
         scaler=None,
         transform=cfg["model"].get("transform", "log"),
     )


### PR DESCRIPTION
## Summary
- avoid altering forecast in `evaluate_prophet_model`
- don't re-transform forecast when evaluating pipeline

## Testing
- `ruff check .`
- `pytest tests/test_metrics.py -q` *(fails: ModuleNotFoundError: No module named 'prophet')*

------
https://chatgpt.com/codex/tasks/task_e_683f271fa4a8832e92d95e8e0a2bbf18