### PR TITLE
Handle extreme call spikes

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ used for further feature engineering.
 The preprocessing step now creates a continuous daily index. Weekend rows are
 inserted with zero call, visit and chatbot counts. Any zero values on weekdays
 are flagged and treated as missing so they can be interpolated. Call volumes
-above the 99th percentile are winsorized to
+above the 99.5th percentile are winsorized to
 reduce the impact of extreme spikes. Dummy variables mark periods for notice
 mail-outs, assessment deadlines, a May 2025 campaign and nearby county
 holidays. Only a 3‑day moving average of visitor counts and raw chatbot


### PR DESCRIPTION
## Summary
- winsorize spikes above the 99.5th percentile in `prepare_data`
- update documentation about winsorization threshold

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `PYTHONPATH=. pytest tests/test_ingestion.py -q` *(fails: ModuleNotFoundError: No module named 'prophet')*

------
https://chatgpt.com/codex/tasks/task_e_683f31394db8832e961cbee548085639