### PR TITLE
Implement automatic likelihood selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ hyperparameters are now tuned for a more flexible trend:
 - `seasonality_prior_scale=0.01`
 - `uncertainty_samples=300`
 - `regressor_prior_scale=0.05`
-- `likelihood=normal`
+- `likelihood=auto` (automatically selects Poisson or negative-binomial)
 - `yearly_seasonality=auto`
 - `weekly_seasonality=false` and a custom weekly component with `fourier_order=5`
 - `capacity` sets the logistic growth cap (defaults to 110% of training max)

--- a/config.yaml
+++ b/config.yaml
@@ -18,7 +18,7 @@ model:
   weekly_seasonality: false
   yearly_seasonality: auto
   daily_seasonality: false
-  likelihood: poisson
+  likelihood: auto
   weekly_incremental: true
   capacity: 1000
   enable_mcmc: false

--- a/pipeline.py
+++ b/pipeline.py
@@ -74,6 +74,7 @@ from prophet_analysis import (
     export_prophet_forecast,
     model_to_json,
     write_summary,
+    select_likelihood,
 )
 
 
@@ -184,6 +185,10 @@ def run_forecast(cfg: dict) -> None:
         press_release_dates=[],
     )
 
+    likelihood = cfg["model"].get("likelihood", "auto")
+    if likelihood == "auto":
+        likelihood = select_likelihood(df["call_count"])
+
     model, forecast, future = train_prophet_model(
         prophet_df,
         holidays,
@@ -191,7 +196,7 @@ def run_forecast(cfg: dict) -> None:
         future_periods=30,
         model_params=model_params,
         prophet_kwargs=prophet_kwargs,
-        likelihood=cfg["model"].get("likelihood", "normal"),
+        likelihood=likelihood,
         transform=cfg["model"].get("transform", "log"),
     )
 

--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -1554,6 +1554,36 @@ def _mean_poisson_deviance(actual, predicted) -> float:
         terms = p - a + a * np.where(a > 0, np.log(a / p), 0.0)
     return float(np.mean(2.0 * terms))
 
+
+def select_likelihood(y: pd.Series, threshold: float = 1.2) -> str:
+    """Return appropriate count likelihood for ``y``.
+
+    The function compares the variance-to-mean ratio of ``y`` against
+    ``threshold``. A ratio greater than the threshold indicates
+    over-dispersion and ``'neg_binomial'`` is returned. Otherwise ``'poisson'``
+    is chosen.
+
+    Parameters
+    ----------
+    y : Series
+        Target count series.
+    threshold : float, optional
+        Ratio above which the negative-binomial likelihood is used.
+
+    Returns
+    -------
+    str
+        ``'neg_binomial'`` or ``'poisson'``.
+    """
+    try:  # ``pandas`` may be stubbed
+        var = float(y.var())
+        mean = float(y.mean())
+    except Exception:
+        return "poisson"
+    if mean > 0 and var / mean > threshold:
+        return "neg_binomial"
+    return "poisson"
+
 def create_simple_ensemble(prophet_df, holidays_df, regressors_df):
     """Create a simple ensemble of multiple Prophet models"""
     logger = logging.getLogger(__name__)

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -1,0 +1,15 @@
+import pytest
+pytest.importorskip("pandas")
+
+import pandas as pd
+from prophet_analysis import select_likelihood
+
+
+def test_select_likelihood_poisson():
+    s = pd.Series([1, 2, 2, 1, 2])
+    assert select_likelihood(s) == "poisson"
+
+
+def test_select_likelihood_neg_binomial():
+    s = pd.Series([1, 10, 1, 10, 1])
+    assert select_likelihood(s) == "neg_binomial"


### PR DESCRIPTION
## Summary
- select Poisson or negative-binomial likelihood based on variance
- expose `select_likelihood` helper in `prophet_analysis`
- use helper in the forecast pipeline
- document new behaviour and default `likelihood: auto`
- test likelihood selection logic

## Testing
- `ruff check pipeline.py prophet_analysis.py tests/test_likelihood.py`
- `USE_STUB_LIBS=1 PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f3265e2c8832e93f9806a2c151e11