### PR TITLE
Support hourly call aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ appropriate tables using a `path.db:table` notation in `config.yaml`:
 ```yaml
 data:
   calls: mydata.db:calls
+  hourly_calls: hourly_call_data.csv  # optional hourly data
   visitors: mydata.db:visits
   queries: mydata.db:queries
 ```
@@ -101,6 +102,8 @@ python data_pipeline.py --config config.yaml --out features.csv
 
 # or specify the CSV files directly
 python data_pipeline.py calls.csv visitors.csv queries.csv --out features.csv
+# optionally include hourly call data to update recent totals
+python data_pipeline.py hourly_call_data.csv visitors.csv queries.csv --out features.csv
 ```
 
 This merges the raw files on a business-day index and adds dummy flags for

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,6 @@
 data:
   calls: calls.csv
+  hourly_calls: hourly_call_data.csv
   visitors: visitors.csv
   queries: queries.csv
 output: prophet_output

--- a/pipeline.py
+++ b/pipeline.py
@@ -135,7 +135,12 @@ def run_forecast(cfg: dict) -> None:
     configure_logging(out_dir / "cmdstan.log")
 
     df, regressors = prepare_data(
-        call_path, visit_path, chat_path, events=cfg.get("events", {}), scale_features=True
+        call_path,
+        visit_path,
+        chat_path,
+        events=cfg.get("events", {}),
+        scale_features=True,
+        hourly_call_path=Path(cfg["data"].get("hourly_calls")) if cfg["data"].get("hourly_calls") else None,
     )
     prophet_df = prepare_prophet_data(df)
 

--- a/tests/test_hourly_ingestion.py
+++ b/tests/test_hourly_ingestion.py
@@ -1,0 +1,16 @@
+import pytest
+pytest.importorskip("pandas")
+
+from pathlib import Path
+
+from prophet_analysis import aggregate_hourly_calls, load_time_series
+
+
+def test_hourly_aggregation_matches_daily():
+    hourly = aggregate_hourly_calls(Path('hourly_call_data.csv'))
+    daily = load_time_series(Path('calls.csv'), metric='call')
+    # Compare first overlapping date
+    common = hourly.index.intersection(daily.index)
+    assert not common.empty
+    first = common[0]
+    assert hourly.loc[first] == daily.loc[first]


### PR DESCRIPTION
## Summary
- allow pipeline to merge hourly call data
- aggregate hourly call data via csv reader
- expose `hourly_calls` path in config and docs
- mention hourly call data in README
- test hourly ingestion

## Testing
- `pytest -q` *(fails: no tests ran because pandas is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68405acc73cc832eae89eb35a4c90891