### PR TITLE
Tune changepoint parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,9 @@ the upcoming business day in a dedicated sheet.
 The Prophet model uses additive seasonality with linear growth. Default
 hyperparameters are now tuned for a more flexible trend:
 
-- `changepoint_prior_scale=0.4`
+- `changepoint_prior_scale` searched from 0.05–0.5
 - `changepoint_range=0.9`
-- `n_changepoints=25`
+- `n_changepoints` searched between 10 and 40
 - `holidays_prior_scale=5`
 - `seasonality_prior_scale=0.01`
 - `uncertainty_samples=300`
@@ -175,10 +175,10 @@ hyperparameters are now tuned for a more flexible trend:
 - `weekly_seasonality=false` and a custom weekly component with `fourier_order=5`
 - `capacity` sets the logistic growth cap (defaults to 110% of training max)
 
-Hyperparameter tuning searches across changepoint, seasonality and holiday prior
-scales using Prophet's rolling cross‑validation to reduce wall time. The grid
-helps avoid under‑ or over‑fitting and targets an MAE no greater than 62 and a
-sMAPE below 32%.
+Hyperparameter tuning relies on rolling cross‑validation. The grid explores
+changepoint scales from 0.05–0.5 and between 10 and 40 changepoints alongside
+the seasonality and holiday priors. This helps avoid under‑ or over‑fitting and
+targets an MAE no greater than 62 with sMAPE under 32%.
 
 You can modify these settings in `config.yaml` if desired. Event windows such as
 campaign dates, policy start and any explicit changepoints also live in the

--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -503,7 +503,8 @@ def tune_prophet_hyperparameters(prophet_df, prophet_kwargs=None, cv_params=None
 
     # Parameter grid
     param_grid = {
-        'changepoint_prior_scale': list(np.logspace(-2, 0, 3)),
+        'changepoint_prior_scale': [0.05, 0.1, 0.2, 0.3, 0.4, 0.5],
+        'n_changepoints': [10, 20, 30, 40],
         'seasonality_prior_scale': list(np.logspace(-2, 0, 3)),
         'holidays_prior_scale': [1.0, 5.0, 10.0],
     }
@@ -528,7 +529,7 @@ def tune_prophet_hyperparameters(prophet_df, prophet_kwargs=None, cv_params=None
                 growth='linear',
                 interval_width=0.9,
                 seasonality_mode='additive',
-                n_changepoints=25,
+                n_changepoints=params.get('n_changepoints', 25),
                 changepoint_range=0.9,
                 **prophet_kwargs,
                 **params,
@@ -570,6 +571,7 @@ def tune_prophet_hyperparameters(prophet_df, prophet_kwargs=None, cv_params=None
         logger.warning("All hyperparameter combinations failed, using defaults")
         return {
             'changepoint_prior_scale': 0.2,
+            'n_changepoints': 25,
             'seasonality_prior_scale': 0.01,
             'holidays_prior_scale': 5,
         }


### PR DESCRIPTION
## Summary
- search changepoint prior scales from 0.05–0.5
- vary n_changepoints between 10 and 40 during tuning
- update README to describe new tuning grid

## Testing
- `ruff check .`
- `PYTHONPATH=. pytest -q tests/test_autocorr_loop.py` *(fails: ModuleNotFoundError: No module named 'prophet')*

------
https://chatgpt.com/codex/tasks/task_e_68405fcc4be8832ea5faa55fc40f57ac