### PR TITLE
Enable Prophet weekly seasonality

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ hyperparameters are now tuned for a more flexible trend:
 - `regressor_prior_scale=0.05`
 - `likelihood=auto` (automatically selects Poisson or negative-binomial)
 - `yearly_seasonality=auto`
-- `weekly_seasonality=false` and a custom weekly component with `fourier_order=5`
+- `weekly_seasonality=auto` or a custom weekly component with `fourier_order=5` when explicitly disabled
 - `capacity` sets the logistic growth cap (defaults to 110% of training max)
 
 Hyperparameter tuning relies on rolling cross‑validation. The grid explores

--- a/config.yaml
+++ b/config.yaml
@@ -16,7 +16,7 @@ model:
   transform: log
   mcmc_samples: 0
   interval_width: 0.9
-  weekly_seasonality: false
+  weekly_seasonality: auto
   yearly_seasonality: auto
   daily_seasonality: false
   use_hourly: false

--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -131,7 +131,7 @@ except Exception:  # pragma: no cover - optional dependency may be missing
 POLICY_LOWER = True
 PROPHET_KWARGS = {
     "yearly_seasonality": "auto",
-    "weekly_seasonality": False,
+    "weekly_seasonality": "auto",
     "daily_seasonality": False,
     "stan_backend": "CMDSTANPY",
 }


### PR DESCRIPTION
## Summary
- allow weekly seasonality to default to `auto`
- change config to use Prophet's automatic weekly seasonality
- document the new default in the README

## Testing
- `ruff check .`
- `USE_STUB_LIBS=1 pytest -q tests -vv`

------
https://chatgpt.com/codex/tasks/task_e_684060b593a0832e8dfe799261978f72