### PR TITLE
Fix pipeline hourly evaluation crash

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -59,6 +59,7 @@ def safe_git_hash() -> str | None:
         return None
 from datetime import datetime
 
+import numpy as np
 import pandas as pd
 from holidays_calendar import get_holidays_dataframe
 from prophet_analysis import (
@@ -342,7 +343,6 @@ def run_forecast(cfg: dict) -> None:
  # ------------------------------------------------------------------
     # Guarantee that both result-tables contain a “MAPE” column
     # ------------------------------------------------------------------
-    import numpy as np
 
     def _ensure_mape(table: pd.DataFrame, obs: str = "y", pred: str = "yhat"):
         """


### PR DESCRIPTION
## Summary
- import numpy at module level to avoid `NameError`

## Testing
- `ruff check .`
- `USE_STUB_LIBS=1 pytest -q` *(tests skipped: pandas stub)*

------
https://chatgpt.com/codex/tasks/task_e_6840697a0524832e9ad837ee8d25fb17