### PR TITLE
Add hybrid short-term blending

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -73,6 +73,7 @@ from prophet_analysis import (
     compute_naive_baseline,
     export_baseline_forecast,
     export_prophet_forecast,
+    blend_short_term,
     model_to_json,
     write_summary,
     select_likelihood,
@@ -353,7 +354,8 @@ def run_forecast(cfg: dict) -> None:
     write_summary(summary, out_dir / "summary.csv")
     write_summary(horizon_table, out_dir / "horizon_metrics.csv")
     diag.to_csv(out_dir / "ljung_box.csv", index=False)
-    export_prophet_forecast(model, forecast, df, out_dir, scaler=None)
+    forecast_blend = blend_short_term(forecast, df)
+    export_prophet_forecast(model, forecast_blend, df, out_dir, scaler=None)
     export_baseline_forecast(df, out_dir)
 
  # ------------------------------------------------------------------

--- a/tests/test_blending.py
+++ b/tests/test_blending.py
@@ -1,0 +1,19 @@
+import pandas as pd
+from prophet_analysis import blend_short_term
+
+
+def test_blend_short_term():
+    forecast = pd.DataFrame({
+        'ds': pd.date_range('2024-01-01', periods=2, freq='D'),
+        'yhat': [100.0, 200.0],
+        'yhat_lower': [90.0, 190.0],
+        'yhat_upper': [110.0, 210.0],
+    })
+    history = pd.DataFrame(
+        {'call_count': range(14)},
+        index=pd.date_range('2023-12-18', periods=14, freq='D'),
+    )
+    blended = blend_short_term(forecast, history, weight=0.5)
+    assert blended.loc[0, 'yhat'] == 53.5
+    assert blended.loc[1, 'yhat'] == 200.0
+


### PR DESCRIPTION
## Summary
- combine naive and Prophet predictions for short horizons
- export the blended forecast
- cover the new function with a unit test

## Testing
- `ruff check .`
- `USE_STUB_LIBS=1 PYTHONPATH=. pytest -q` *(fails: no tests run)*

------
https://chatgpt.com/codex/tasks/task_e_68406f31c438832e874542585b10ca02