### PR TITLE
Implement residual monitoring and auto retrain

### DIFF
--- a/tests/test_residual_monitoring.py
+++ b/tests/test_residual_monitoring.py
@@ -1,0 +1,18 @@
+import pytest
+pytest.importorskip("pandas")
+
+import pandas as pd
+from prophet_analysis import monitor_residuals
+
+
+def test_monitor_residuals_flags_large_error():
+    dates = pd.date_range("2023-01-01", periods=20, freq="D")
+    df = pd.DataFrame({
+        "ds": dates,
+        "yhat": [10.0] * 20,
+        "actual": [10.0] * 20,
+    })
+    df.loc[14, "yhat"] = 0.0
+    flagged = monitor_residuals(df)
+    assert not flagged.empty
+    assert flagged.iloc[0]["ds"] == dates[14]


### PR DESCRIPTION
## Summary
- return forecast dataframe from `export_prophet_forecast`
- add `monitor_residuals` utility to flag days with large residuals
- re-export Prophet forecast when residuals spike
- test residual monitoring

## Testing
- `ruff check pipeline.py prophet_analysis.py tests/test_residual_monitoring.py`
- `USE_STUB_LIBS=1 pytest -q` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68407276d13c832eaf0613f17ebe9c81