### PR TITLE
Adjust interval width for over-dispersion

### DIFF
--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -3002,6 +3002,14 @@ def evaluate_prophet_model(
         coverage = (
             ((df_cv['y'] >= df_cv['yhat_lower']) & (df_cv['y'] <= df_cv['yhat_upper'])).mean() * 100
         )
+    elif coverage == coverage and coverage > 95:
+        interval_scale = 0.95
+        center = df_cv['yhat']
+        df_cv['yhat_lower'] = center - (center - df_cv['yhat_lower']) * interval_scale
+        df_cv['yhat_upper'] = center + (df_cv['yhat_upper'] - center) * interval_scale
+        coverage = (
+            ((df_cv['y'] >= df_cv['yhat_lower']) & (df_cv['y'] <= df_cv['yhat_upper'])).mean() * 100
+        )
 
     logger.info(
         f"Cross‑validation →  MAE {mae:.2f} | RMSE {rmse:.2f} | "


### PR DESCRIPTION
## Summary
- scale down forecast intervals by 5% when coverage exceeds 95%

## Testing
- `ruff check .`
- `pytest -q` *(tests skipped: pandas not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684073c18fd4832e94f3fd53a5cdddd6