### PR TITLE
Enhance hourly analysis with MAE metrics

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -143,11 +143,13 @@ def run_forecast(cfg: dict) -> None:
         if not hourly_path:
             raise ValueError("hourly_calls path required when use_hourly is true")
         periods = cfg["model"].get("hourly_periods", 24 * 7)
-        model, hourly_fcst, daily_fcst = forecast_hourly_to_daily(
+        model, hourly_fcst, daily_fcst, hour_metrics = forecast_hourly_to_daily(
             Path(hourly_path), periods=periods
         )
         hourly_fcst.to_csv(out_dir / "hourly_forecast.csv", index=False)
         daily_fcst.to_csv(out_dir / "daily_forecast.csv")
+        if hour_metrics is not None:
+            hour_metrics.to_csv(out_dir / "hour_of_day_metrics.csv", index=False)
 
         df_hourly = pd.read_csv(hourly_path)
         df_hourly["ds"] = pd.to_datetime(df_hourly.iloc[:, 0], format="%m/%d/%Y %H:%M")

--- a/tests/test_hourly_forecast.py
+++ b/tests/test_hourly_forecast.py
@@ -5,6 +5,8 @@ from hourly_analysis import forecast_hourly_to_daily
 
 
 def test_forecast_hourly_to_daily():
-    _, _, daily = forecast_hourly_to_daily('hourly_call_data.csv', periods=24)
+    _, _, daily, hour_metrics = forecast_hourly_to_daily('hourly_call_data.csv', periods=24)
     assert not daily.empty
     assert len(daily) >= 1
+    assert hour_metrics is not None
+    assert 'MAE' in hour_metrics.columns


### PR DESCRIPTION
## Summary
- compute hour-of-day MAE and bias for hourly forecasts
- adjust Prophet seasonality prior if systematic bias detected
- export hourly error metrics from the pipeline
- update hourly forecast tests for new return value

## Testing
- `ruff check .`
- `pytest -q` *(tests skipped: pandas not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684078e39320832eaddc1eb06366a0b4