### PR TITLE
Implement zero-call hurdle metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,9 @@ aggregated daily totals to ``daily_forecast.csv``.
 
 The preprocessing step now creates a continuous daily index. Weekend rows are
 inserted with zero call, visit and chatbot counts. Any zero values on weekdays
-are flagged and treated as missing so they can be interpolated. Call volumes
+are flagged and treated as missing so they can be interpolated. Zero-call days
+are evaluated separately using a hurdle-style metric so they do not distort
+percentage errors. Call volumes
 above the 99.5th percentile are winsorized to
 reduce the impact of extreme spikes. Dummy variables mark periods for notice
 mail-outs, assessment deadlines, a May 2025 campaign and nearby county

--- a/pipeline.py
+++ b/pipeline.py
@@ -172,6 +172,7 @@ def run_forecast(cfg: dict) -> None:
                 ).mean()
                 * 100
             )
+            zero_acc = ((joined["actual"] == 0) == (joined["yhat"] < 0.5)).mean() * 100
             smape = (
                 2
                 * joined["abs_error"]
@@ -180,12 +181,13 @@ def run_forecast(cfg: dict) -> None:
             ).replace([np.inf, -np.inf], np.nan).mean() * 100
             summary = pd.DataFrame(
                 {
-                    "metric": ["MAE", "RMSE", "sMAPE", "Coverage"],
+                    "metric": ["MAE", "RMSE", "sMAPE", "Coverage", "ZeroAcc"],
                     "value": [
                         joined["abs_error"].mean(),
                         np.sqrt((joined["error"] ** 2).mean()),
                         smape,
                         coverage,
+                        zero_acc,
                     ],
                 }
             )
@@ -205,10 +207,11 @@ def run_forecast(cfg: dict) -> None:
                                 (sub["actual"].abs() + sub["yhat"].abs())
                             ).replace([np.inf, -np.inf], np.nan).mean()
                             * 100,
+                            ((sub["actual"] == 0) == (sub["yhat"] < 0.5)).mean() * 100,
                         ]
                     )
             horizon_df = pd.DataFrame(
-                horizon_rows, columns=["horizon_days", "MAE", "RMSE", "sMAPE"]
+                horizon_rows, columns=["horizon_days", "MAE", "RMSE", "sMAPE", "ZeroAcc"]
             )
             return summary, horizon_df
 
@@ -248,7 +251,7 @@ def run_forecast(cfg: dict) -> None:
         prophet_metrics["model"] = "prophet"
         prophet_metrics["coverage"] = coverage
 
-        wanted = ["model", "horizon", "MAE", "RMSE", "sMAPE", "coverage"]
+        wanted = ["model", "horizon", "MAE", "RMSE", "sMAPE", "coverage", "ZeroAcc"]
         metrics_baseline = metrics_baseline[[c for c in wanted if c in metrics_baseline]]
         prophet_metrics = prophet_metrics[[c for c in wanted if c in prophet_metrics]]
 
@@ -418,7 +421,7 @@ def run_forecast(cfg: dict) -> None:
     prophet_metrics["model"] = "prophet"
     prophet_metrics["coverage"] = coverage
 
-    wanted = ["model", "horizon", "MAE", "RMSE", "sMAPE", "coverage"]
+    wanted = ["model", "horizon", "MAE", "RMSE", "sMAPE", "coverage", "ZeroAcc"]
     metrics_baseline = metrics_baseline[[c for c in wanted if c in metrics_baseline]]
     prophet_metrics  = prophet_metrics [[c for c in wanted if c in prophet_metrics ]]
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -10,7 +10,9 @@ def test_baseline_returns_smape():
     df = pd.DataFrame({'call_count': range(30)}, index=dates)
     _, metrics, horizon = compute_naive_baseline(df)
     assert 'sMAPE' in metrics['metric'].tolist()
+    assert 'ZeroAcc' in metrics['metric'].tolist()
     assert 'sMAPE' in horizon.columns
+    assert 'ZeroAcc' in horizon.columns
 
 
 def _stub_cv(*_args, **_kwargs):
@@ -34,4 +36,6 @@ def test_prophet_evaluation_includes_smape():
          patch('prophet_analysis._ensure_tbb_on_path'):
         _, horizon_table, summary, _, _ = evaluate_prophet_model(model, prophet_df)
     assert 'sMAPE' in summary['metric'].tolist()
+    assert 'ZeroAcc' in summary['metric'].tolist()
     assert 'sMAPE' in horizon_table.columns
+    assert 'ZeroAcc' in horizon_table.columns


### PR DESCRIPTION
## Summary
- add a hurdle-style metric to handle zero-call days
- surface ZeroAcc in pipeline metrics and baseline evaluation
- test for ZeroAcc columns
- document the new hurdle approach

## Testing
- `pytest -q` *(fails: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68407a054b9c832ea36312948885739c