### PR TITLE
Limit hourly data to open hours

### DIFF
--- a/hourly_analysis.py
+++ b/hourly_analysis.py
@@ -41,6 +41,12 @@ def forecast_hourly_to_daily(
     df["ds"] = pd.to_datetime(df.iloc[:, 0], format="%m/%d/%Y %H:%M")
     df["y"] = df.iloc[:, 1].astype(float)
 
+    # ------------------------------------------------------------------
+    # Restrict to open hours: weekdays 08:00-16:59
+    # ------------------------------------------------------------------
+    df = df[df.ds.dt.weekday < 5]
+    df = df[(df.ds.dt.hour >= 8) & (df.ds.dt.hour < 17)]
+
     hourly_metrics = None
 
     if Prophet is not None and hasattr(Prophet, "fit"):

--- a/pipeline.py
+++ b/pipeline.py
@@ -155,7 +155,15 @@ def run_forecast(cfg: dict) -> None:
         df_hourly["ds"] = pd.to_datetime(df_hourly.iloc[:, 0], format="%m/%d/%Y %H:%M")
         df_hourly["y"] = df_hourly.iloc[:, 1].astype(float)
 
+        # --------------------------------------------------------------
+        # Restrict evaluation to open hours (weekdays 08:00-16:59)
+        # --------------------------------------------------------------
+        df_hourly = df_hourly[df_hourly.ds.dt.weekday < 5]
+        df_hourly = df_hourly[(df_hourly.ds.dt.hour >= 8) & (df_hourly.ds.dt.hour < 17)]
+
         def _evaluate_hourly(df: pd.DataFrame, fcst: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame]:
+            fcst = fcst[fcst.ds.dt.weekday < 5]
+            fcst = fcst[(fcst.ds.dt.hour >= 8) & (fcst.ds.dt.hour < 17)]
             joined = pd.concat(
                 [
                     df.set_index("ds")["y"].resample("D").sum().rename("actual"),


### PR DESCRIPTION
## Summary
- filter hourly data to weekday open hours in `hourly_analysis`
- restrict hourly evaluation in `pipeline` to those hours

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684080e4d018832eb5b5bfe1a84edfa3