### PR TITLE
Document operating hours constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ python hourly_analysis.py hourly_call_data.csv --periods 168 --out hourly_foreca
 The script writes the raw hourly forecast to ``hourly_forecast.csv`` and the
 aggregated daily totals to ``daily_forecast.csv``.
 
+Forecasting assumes the call centre only operates Monday–Friday between
+08:00 and 17:00. Any hourly records outside this window are removed prior to
+training and evaluation so metrics reflect normal operating hours.
+
 ### Data exclusions
 
 The preprocessing step now creates a continuous daily index. Weekend rows are
@@ -155,10 +159,11 @@ scale.
 The results, including forecasts and plots, will be saved in the specified output directory.
 The exported CSV file (`prophet_call_predictions_<hash>.csv`) now includes
 predictions for the previous 14 business days along with a forecast for the next
-business day. A seasonal naive baseline forecast using the call volume from the
-same weekday in the prior week and the corresponding MAE, RMSE and Poisson
-deviance metrics are also included. The report additionally lists the predicted call volume for
-the upcoming business day in a dedicated sheet.
+business day. A seasonal naive baseline forecast now uses call volume from the
+same hour and weekday one week earlier, aggregated to daily totals. The
+corresponding MAE, RMSE and Poisson deviance metrics are also included. The
+report additionally lists the predicted call volume for the upcoming business
+day in a dedicated sheet.
 
 Each run logs the training window, any parameter overrides and a SHA1 hash of the
 serialized model so forecasts can be exactly reproduced.

--- a/config.yaml
+++ b/config.yaml
@@ -15,7 +15,7 @@ model:
   growth: linear
   transform: log
   mcmc_samples: 0
-  interval_width: 0.9
+  interval_width: 0.83
   weekly_seasonality: auto
   yearly_seasonality: auto
   daily_seasonality: false

--- a/model_log.md
+++ b/model_log.md
@@ -11,3 +11,9 @@
 
 - Added standardized 7-day lags for visitor and query counts as new regressors.
 - These features explain more than 65% of the forecastable variance one week ahead.
+
+## Model Log - 2025-06-10
+
+- Hourly forecasts exclude weekends and any times outside of 08:00–17:00.
+  This masked-window assumption ensures the model represents normal
+  operating hours only.

--- a/naive_forecast.py
+++ b/naive_forecast.py
@@ -1,9 +1,5 @@
-"""Seasonal naive forecast using last week's value.
+"""Seasonal naive forecast using last week's same hour."""
 
-This script reads ``calls.csv`` and produces predictions for the last
-14 days using the value from the same weekday in the prior week as the
-prediction. It reports MAE and RMSE to compare predictions to actual values.
-"""
 import csv
 from datetime import datetime
 from math import sqrt
@@ -11,48 +7,57 @@ from math import sqrt
 
 def main() -> None:
     rows = []
-    with open("calls.csv") as f:
+    with open("hourly_call_data.csv") as f:
         reader = csv.reader(f)
+        next(reader, None)
         for row in reader:
             if not row:
                 continue
-            date_str, value_str = row
-            parsed = None
-            for fmt in ("%m/%d/%Y", "%m/%d/%y"):
-                try:
-                    parsed = datetime.strptime(date_str.strip(), fmt)
-                    break
-                except ValueError:
-                    continue
-            if not parsed:
-                # skip header or malformed lines
+            ts_str, val_str = row[:2]
+            try:
+                dt = datetime.strptime(ts_str.strip(), "%m/%d/%Y %H:%M")
+            except ValueError:
                 continue
-            date = parsed
-            rows.append((date.strftime("%Y-%m-%d"), float(value_str)))
+            rows.append((dt, float(val_str)))
 
-    # Ensure data is sorted by date
     rows.sort(key=lambda x: x[0])
-
-    # Need one week of extra history for the seasonal naive baseline
-    recent = rows[-21:]
+    if len(rows) < 24 * 21:
+        raise SystemExit("Need at least 21 days of hourly data")
 
     preds = []
     acts = []
     dates = []
-    for i in range(7, len(recent)):
-        pred = recent[i - 7][1]
-        actual = recent[i][1]
-        preds.append(pred)
-        acts.append(actual)
-        dates.append(recent[i][0])
+    for i in range(24 * 7, len(rows)):
+        preds.append(rows[i - 24 * 7][1])
+        acts.append(rows[i][1])
+        dates.append(rows[i][0])
 
-    # Compute metrics
-    n = len(preds)
-    mae = sum(abs(a - p) for a, p in zip(acts, preds)) / n
-    rmse = sqrt(sum((a - p) ** 2 for a, p in zip(acts, preds)) / n)
+    preds = preds[-24 * 14:]
+    acts = acts[-24 * 14:]
+    dates = dates[-24 * 14:]
+
+    filtered = [
+        (d, p, a)
+        for d, p, a in zip(dates, preds, acts)
+        if d.weekday() < 5 and 8 <= d.hour < 17
+    ]
+
+    daily = {}
+    for d, p, a in filtered:
+        day = d.date()
+        pred, act = daily.get(day, (0.0, 0.0))
+        daily[day] = (pred + p, act + a)
+
+    dates_out = list(daily.keys())
+    preds_out = [v[0] for v in daily.values()]
+    acts_out = [v[1] for v in daily.values()]
+
+    n = len(preds_out)
+    mae = sum(abs(a - p) for a, p in zip(acts_out, preds_out)) / n
+    rmse = sqrt(sum((a - p) ** 2 for a, p in zip(acts_out, preds_out)) / n)
 
     print("date,predicted,actual")
-    for d, p, a in zip(dates, preds, acts):
+    for d, p, a in zip(dates_out, preds_out, acts_out):
         print(f"{d},{p},{a}")
 
     print(f"MAE,{mae:.2f}")

--- a/pipeline.py
+++ b/pipeline.py
@@ -269,7 +269,10 @@ def run_forecast(cfg: dict) -> None:
 
         _ensure_smape(horizon_table)
 
-        baseline_df, baseline_metrics, baseline_horizon = compute_naive_baseline(df_daily)
+        baseline_df, baseline_metrics, baseline_horizon = compute_naive_baseline(
+            df_daily,
+            hourly_df=df_hourly[["ds", "y"]],
+        )
         _ensure_smape(baseline_horizon, obs="call_count", pred="predicted")
         cov_b = baseline_metrics.loc[
             baseline_metrics["metric"] == "Coverage", "value"


### PR DESCRIPTION
## Summary
- note hourly operating hours in README
- log masked-window assumption in model spec
- rebuild naive baseline with per-hour lag
- tighten prediction intervals via config

## Testing
- `pytest -q` *(fails: no tests executed)*
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6840870a57a8832ea04c94b8f84b3791