### PR TITLE
Fix baseline coverage check

### DIFF
--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -2592,12 +2592,13 @@ def compute_naive_baseline(
         preds = recent.shift(7).iloc[-14:]
         actual = recent.iloc[-14:]
         dates = recent.index[-14:]
-
-    result = pd.DataFrame({
-        "date": dates,
-        "predicted": preds.values,
-        "actual": actual.values,
-    })
+        result = pd.DataFrame(
+            {
+                "date": dates,
+                "predicted": preds.values,
+                "actual": actual.values,
+            }
+        )
     # Drop rows with missing values to avoid NaNs propagating through the
     # metrics calculations. This can occur when the input series contains
     # gaps or when there is insufficient history for a 7‑day lag.


### PR DESCRIPTION
## Summary
- fix undefined variable when hourly data is provided in `compute_naive_baseline`

## Testing
- `pytest -q tests/test_baseline_coverage_range.py -vv` *(fails: No module named 'prophet')*
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68409f557328832e8c547fbf6eb288e1