### PR TITLE
Fix baseline coverage logger usage

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -519,6 +519,7 @@ def run_forecast(cfg: dict) -> None:
 
 def check_baseline_coverage(config_path: Path) -> None:
     """Print naive baseline coverage and exit if outside 88-92 percent."""
+    logger = logging.getLogger(__name__)
     cfg = load_config(config_path)
     calls = load_time_series(Path(cfg["data"]["calls"]), metric="call")
     df = pd.DataFrame({"call_count": calls})


### PR DESCRIPTION
## Summary
- add missing logger in `check_baseline_coverage`

## Testing
- `ruff check .`
- `pytest -q` *(fails: no tests ran)*
- `USE_STUB_LIBS=1 pytest -q tests/test_baseline_coverage_range.py -vv` *(fails to import `prophet_analysis`)*

------
https://chatgpt.com/codex/tasks/task_e_6840a2f64a20832e8b3d7f4df3b63597