### PR TITLE
Add baseline coverage CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ running the model:
 python pipeline.py config.yaml --check-baseline-coverage
 ```
 
+Alternatively `--baseline-coverage` prints the value and exits with code 1 when
+the coverage falls outside the 88–92% range:
+
+```bash
+python pipeline.py config.yaml --baseline-coverage
+```
+
 The CLI now serves as a thin wrapper around the YAML-driven pipeline. All model
 parameters, including input and output paths, are read from `config.yaml`.
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -518,7 +518,10 @@ def run_forecast(cfg: dict) -> None:
 
 
 def check_baseline_coverage(config_path: Path) -> None:
-    """Print naive baseline coverage and exit if outside 88-92 percent."""
+    """Print naive baseline coverage and exit if outside 88‑92 percent.
+
+    Uses ``pandas`` from the open‑source ecosystem to load the data.
+    """
     logger = logging.getLogger(__name__)
     cfg = load_config(config_path)
     calls = load_time_series(Path(cfg["data"]["calls"]), metric="call")
@@ -561,8 +564,13 @@ if __name__ == "__main__":
         action="store_true",
         help="Verify naive baseline coverage is between 88 and 92",
     )
+    p.add_argument(
+        "--baseline-coverage",
+        action="store_true",
+        help="Print naive baseline coverage and exit 1 if outside 88-92",
+    )
     args = p.parse_args()
-    if args.check_baseline_coverage:
+    if args.baseline_coverage or args.check_baseline_coverage:
         check_baseline_coverage(args.config)
     else:
         pipeline(args.config)

--- a/tests/test_cli_baseline_coverage.py
+++ b/tests/test_cli_baseline_coverage.py
@@ -1,0 +1,14 @@
+import subprocess
+import sys
+import pytest
+pytest.importorskip("pandas")
+
+
+def test_cli_baseline_coverage():
+    result = subprocess.run(
+        [sys.executable, "pipeline.py", "config.yaml", "--baseline-coverage"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "Naive baseline coverage:" in result.stdout


### PR DESCRIPTION
## Summary
- add `--baseline-coverage` argument to `pipeline.py`
- document new option in README
- test baseline coverage CLI

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840a4508d9c832e831cff86399cb066