### PR TITLE
Switch scorecards to WAPE and add interval metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ python hourly_analysis.py hourly_call_data.csv --periods 168 --out hourly_foreca
 The script writes the raw hourly forecast to ``hourly_forecast.csv`` and the
 aggregated daily totals to ``daily_forecast.csv``.
 
+Accuracy at the 15‑ and 30‑minute level can be assessed with
+``compute_interval_accuracy`` which compares consecutive interval predictions
+against the actual counts.
+
 Forecasting assumes the call centre only operates Monday–Friday between
 08:00 and 17:00. Any hourly records outside this window are removed prior to
 training and evaluation so metrics reflect normal operating hours.
@@ -200,9 +204,9 @@ hyperparameters are now tuned for a more flexible trend:
 - `capacity` sets the logistic growth cap (defaults to 110% of training max)
 
 Hyperparameter tuning relies on rolling cross‑validation. The grid explores
-changepoint scales from 0.05–0.5 and between 10 and 40 changepoints alongside
-the seasonality and holiday priors. This helps avoid under‑ or over‑fitting and
-targets an MAE no greater than 62 with sMAPE under 32%.
+ changepoint scales from 0.05–0.5 and between 10 and 40 changepoints alongside
+ the seasonality and holiday priors. This helps avoid under‑ or over‑fitting and
+ targets an MAE no greater than 62 with WAPE under 32%.
 
 You can modify these settings in `config.yaml` if desired. Event windows such as
 campaign dates, policy start and any explicit changepoints also live in the

--- a/prophet_analysis.py
+++ b/prophet_analysis.py
@@ -562,14 +562,12 @@ def tune_prophet_hyperparameters(prophet_df, prophet_kwargs=None, cv_params=None
             else:
                 metrics_df = None
                 mae = np.mean(np.abs(df_cv['y'] - df_cv['yhat']))
-            smape = (
-                2
-                * np.abs(df_cv['y'] - df_cv['yhat'])
-                /
-                (df_cv['y'].abs() + df_cv['yhat'].abs())
-            ).replace([np.inf, -np.inf], np.nan).mean() * 100
-            logger.info("→ MAE %.2f | sMAPE %.2f", mae, smape)
-            results.append((mae, smape, params))
+            wape = (
+                np.abs(df_cv['y'] - df_cv['yhat']).sum()
+                / df_cv['y'].abs().sum()
+            ) * 100
+            logger.info("→ MAE %.2f | WAPE %.2f", mae, wape)
+            results.append((mae, wape, params))
         except Exception as e:
             logger.warning("Error with hyperparameter combination %s: %s", params, str(e))
 
@@ -582,14 +580,14 @@ def tune_prophet_hyperparameters(prophet_df, prophet_kwargs=None, cv_params=None
             'holidays_prior_scale': 5,
         }
 
-    best_mae, best_smape, best_params = min(results, key=lambda r: r[0])
-    if best_mae <= 62 and best_smape <= 32:
-        logger.info("Best parameters meet target metrics: MAE %.2f, sMAPE %.2f", best_mae, best_smape)
+    best_mae, best_wape, best_params = min(results, key=lambda r: r[0])
+    if best_mae <= 62 and best_wape <= 32:
+        logger.info("Best parameters meet target metrics: MAE %.2f, WAPE %.2f", best_mae, best_wape)
     else:
         logger.warning(
-            "Best parameters did not meet target metrics: MAE %.2f, sMAPE %.2f",
+            "Best parameters did not meet target metrics: MAE %.2f, WAPE %.2f",
             best_mae,
-            best_smape,
+            best_wape,
         )
 
     logger.info("Best parameters found: %s", best_params)
@@ -2612,12 +2610,7 @@ def compute_naive_baseline(
     result["abs_error"] = result["error"].abs()
     mae = result["abs_error"].mean()
     rmse = np.sqrt((result["error"] ** 2).mean())
-    smape = (
-        2
-        * result["abs_error"]
-        /
-        (result["actual"].abs() + result["predicted"].abs())
-    ).replace([np.inf, -np.inf], np.nan).mean() * 100
+    wape = result["abs_error"].sum() / result["actual"].abs().sum() * 100
     pdev = _mean_poisson_deviance(result["actual"], result["predicted"])
 
     resid_std = result["error"].std(ddof=0)
@@ -2634,8 +2627,8 @@ def compute_naive_baseline(
 
     metrics = pd.DataFrame(
         {
-            "metric": ["MAE", "RMSE", "sMAPE", "Poisson", "Coverage", "ZeroAcc"],
-            "value": [mae, rmse, smape, pdev, coverage, zero_acc],
+            "metric": ["MAE", "RMSE", "WAPE", "Poisson", "Coverage", "ZeroAcc"],
+            "value": [mae, rmse, wape, pdev, coverage, zero_acc],
         }
     )
 
@@ -2645,21 +2638,38 @@ def compute_naive_baseline(
             sub = result.head(h)
             mae_h = sub["abs_error"].mean()
             rmse_h = np.sqrt((sub["error"] ** 2).mean())
-            smape_h = (
-                2
-                * sub["abs_error"]
-                /
-                (sub["actual"].abs() + sub["predicted"].abs())
-            ).replace([np.inf, -np.inf], np.nan).mean() * 100
+            wape_h = sub["abs_error"].sum() / sub["actual"].abs().sum() * 100
             pdev_h = _mean_poisson_deviance(sub["actual"], sub["predicted"])
             zero_h = ((sub["actual"] == 0) == (sub["predicted"] < 0.5)).mean() * 100
-            horizon_rows.append([h, mae_h, rmse_h, smape_h, pdev_h, zero_h])
+            horizon_rows.append([h, mae_h, rmse_h, wape_h, pdev_h, zero_h])
     horizon_df = pd.DataFrame(
-        horizon_rows, columns=["horizon_days", "MAE", "RMSE", "sMAPE", "Poisson", "ZeroAcc"]
+        horizon_rows, columns=["horizon_days", "MAE", "RMSE", "WAPE", "Poisson", "ZeroAcc"]
     )
 
 
     return result, metrics, horizon_df
+
+
+def compute_interval_accuracy(path: Path) -> pd.DataFrame:
+    """Return MAE, RMSE and WAPE for consecutive-interval forecasts.
+
+    The CSV at ``path`` must contain a timestamp column followed by the actual
+    call count. Accuracy is computed against a naive persistence forecast using
+    the previous interval's value.
+    """
+
+    df = pd.read_csv(path)
+    df["ds"] = pd.to_datetime(df.iloc[:, 0])
+    df["y"] = df.iloc[:, 1].astype(float)
+    df = df.sort_values("ds")
+    df["pred"] = df["y"].shift(1)
+    df = df.dropna()
+    error = df["y"] - df["pred"]
+    abs_error = error.abs()
+    mae = abs_error.mean()
+    rmse = np.sqrt((error ** 2).mean())
+    wape = abs_error.sum() / df["y"].abs().sum() * 100
+    return pd.DataFrame({"metric": ["MAE", "RMSE", "WAPE"], "value": [mae, rmse, wape]})
 
 
 def write_summary(df: pd.DataFrame, path: Path) -> Path:
@@ -3054,12 +3064,10 @@ def evaluate_prophet_model(
 
     mae  = metrics_df['mae' ].mean() if metrics_df is not None and 'mae'  in metrics_df else float('nan')
     rmse = metrics_df['rmse'].mean() if metrics_df is not None and 'rmse' in metrics_df else float('nan')
-    smape = (
-        2
-        * np.abs(df_cv['y'] - df_cv['yhat'])
-        /
-        (df_cv['y'].abs() + df_cv['yhat'].abs())
-    ).replace([np.inf, -np.inf], np.nan).mean() * 100
+    wape = (
+        np.abs(df_cv['y'] - df_cv['yhat']).sum()
+        / df_cv['y'].abs().sum()
+    ) * 100
     pdev = _mean_poisson_deviance(df_cv['y'], df_cv['yhat'])
 
     coverage = (
@@ -3090,7 +3098,7 @@ def evaluate_prophet_model(
 
     logger.info(
         f"Cross‑validation →  MAE {mae:.2f} | RMSE {rmse:.2f} | "
-        f"sMAPE {smape:.2f} | Poisson {pdev:.2f} | "
+        f"WAPE {wape:.2f} | Poisson {pdev:.2f} | "
         f"Coverage {coverage if coverage==coverage else 'N/A'}%"
     )
 
@@ -3136,8 +3144,8 @@ def evaluate_prophet_model(
             break
 
     summary = pd.DataFrame({
-        "metric": ["MAE", "RMSE", "sMAPE", "Poisson", "Coverage", "ZeroAcc"],
-        "value":  [mae,  rmse,  smape,  pdev, coverage, zero_acc]
+        "metric": ["MAE", "RMSE", "WAPE", "Poisson", "Coverage", "ZeroAcc"],
+        "value":  [mae,  rmse,  wape,  pdev, coverage, zero_acc]
     })
 
     horizon_rows = []
@@ -3148,17 +3156,15 @@ def evaluate_prophet_model(
             continue
         mae_h = np.mean(np.abs(sub['y'] - sub['yhat']))
         rmse_h = np.sqrt(mean_squared_error(sub['y'], sub['yhat']))
-        smape_h = (
-            2
-            * np.abs(sub['y'] - sub['yhat'])
-            /
-            (sub['y'].abs() + sub['yhat'].abs())
-        ).replace([np.inf, -np.inf], np.nan).mean() * 100
+        wape_h = (
+            np.abs(sub['y'] - sub['yhat']).sum()
+            / sub['y'].abs().sum()
+        ) * 100
         pdev_h = _mean_poisson_deviance(sub['y'], sub['yhat'])
         zero_h = ((sub['y'] == 0) == (sub['yhat'] < 0.5)).mean() * 100
-        horizon_rows.append([h, mae_h, rmse_h, smape_h, pdev_h, zero_h])
+        horizon_rows.append([h, mae_h, rmse_h, wape_h, pdev_h, zero_h])
     horizon_table = pd.DataFrame(
-        horizon_rows, columns=['horizon_days','MAE','RMSE','sMAPE','Poisson','ZeroAcc']
+        horizon_rows, columns=['horizon_days','MAE','RMSE','WAPE','Poisson','ZeroAcc']
     )
 
     _check_horizon_escalation(horizon_table)

--- a/tests/test_interval_accuracy.py
+++ b/tests/test_interval_accuracy.py
@@ -1,0 +1,15 @@
+import pytest
+pytest.importorskip("pandas")
+
+from pathlib import Path
+from prophet_analysis import compute_interval_accuracy
+
+
+def test_interval_accuracy_15():
+    metrics = compute_interval_accuracy(Path('15_Minute_Call_Counts.csv'))
+    assert 'WAPE' in metrics['metric'].tolist()
+
+
+def test_interval_accuracy_30():
+    metrics = compute_interval_accuracy(Path('30_Minute_Call_Counts.csv'))
+    assert 'WAPE' in metrics['metric'].tolist()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -5,13 +5,13 @@ from prophet_analysis import compute_naive_baseline, evaluate_prophet_model
 from tests.test_pipeline_alignment import DummyProphet
 
 
-def test_baseline_returns_smape():
+def test_baseline_returns_wape():
     dates = pd.date_range('2023-01-01', periods=30, freq='D')
     df = pd.DataFrame({'call_count': range(30)}, index=dates)
     _, metrics, horizon = compute_naive_baseline(df)
-    assert 'sMAPE' in metrics['metric'].tolist()
+    assert 'WAPE' in metrics['metric'].tolist()
     assert 'ZeroAcc' in metrics['metric'].tolist()
-    assert 'sMAPE' in horizon.columns
+    assert 'WAPE' in horizon.columns
     assert 'ZeroAcc' in horizon.columns
 
 
@@ -27,7 +27,7 @@ def _lb_mid(residuals, lags=14, return_df=True):
     return pd.DataFrame({'lb_stat': [0.0] * lags, 'lb_pvalue': [0.5] * lags})
 
 
-def test_prophet_evaluation_includes_smape():
+def test_prophet_evaluation_includes_wape():
     model = DummyProphet()
     prophet_df = pd.DataFrame({'ds': pd.date_range('2023-01-01', periods=3), 'y': [1, 2, 3]})
     with patch('prophet_analysis.cross_validation_func', side_effect=_stub_cv), \
@@ -35,7 +35,7 @@ def test_prophet_evaluation_includes_smape():
          patch('prophet_analysis._fit_prophet_with_fallback'), \
          patch('prophet_analysis._ensure_tbb_on_path'):
         _, horizon_table, summary, _, _ = evaluate_prophet_model(model, prophet_df)
-    assert 'sMAPE' in summary['metric'].tolist()
+    assert 'WAPE' in summary['metric'].tolist()
     assert 'ZeroAcc' in summary['metric'].tolist()
-    assert 'sMAPE' in horizon_table.columns
+    assert 'WAPE' in horizon_table.columns
     assert 'ZeroAcc' in horizon_table.columns


### PR DESCRIPTION
## Summary
- replace all sMAPE calculations with WAPE
- support evaluating 15‑ and 30‑minute interval accuracy
- update tests for new WAPE metric
- document WAPE usage and interval accuracy helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840b5b15ee4832ea58e6e90267166d1