### PR TITLE
Add hourly stats and model gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,13 @@ hourly basis and then sum the predictions to daily totals. It falls back to a
 naive mean forecast when the real ``prophet`` package is unavailable so the unit
 tests still run with the bundled stubs.
 
+The hourly workflow now records the mean and standard deviation for each
+weekday-hour combination. These statistics are written to ``hourly_stats.csv``
+whenever the model retrains. Two regressors expose them to Prophet: ``open_flag``
+marks business hours while ``mean_hour`` represents the typical call volume for
+that hour of the week. A new model is only promoted when it beats the naive mean
+benchmark by at least 10 % in MAE or WAPE.
+
 Alternatively, the YAML-driven pipeline can perform the same operation when
 `model.use_hourly` is enabled.
 

--- a/model_log.md
+++ b/model_log.md
@@ -17,3 +17,11 @@
 - Hourly forecasts exclude weekends and any times outside of 08:00–17:00.
   This masked-window assumption ensures the model represents normal
   operating hours only.
+
+## Model Log - 2025-06-18
+
+- Computed hourly mean and standard deviation for each weekday-hour pair.
+- Stored the table as ``hourly_stats.csv`` at every retrain.
+- Added ``open_flag`` and ``mean_hour`` regressors with prior scales 20 and 5
+  respectively. Models are promoted only when they improve MAE or WAPE by at
+  least 10 % over the naive mean baseline.

--- a/tests/test_hourly_forecast.py
+++ b/tests/test_hourly_forecast.py
@@ -5,8 +5,10 @@ from hourly_analysis import forecast_hourly_to_daily
 
 
 def test_forecast_hourly_to_daily():
-    _, _, daily, hour_metrics = forecast_hourly_to_daily('hourly_call_data.csv', periods=24)
+    _, _, daily, hour_metrics, stats = forecast_hourly_to_daily('hourly_call_data.csv', periods=24)
     assert not daily.empty
     assert len(daily) >= 1
     assert hour_metrics is not None
     assert 'MAE' in hour_metrics.columns
+    assert not stats.empty
+    assert {'dow', 'hour', 'mean', 'std'} <= set(stats.columns)


### PR DESCRIPTION
## Summary
- compute hourly mean/std per weekday-hour and expose as features
- store hourly_stats.csv with hourly training data
- gate model promotion on 10% MAE/WAPE improvement
- document the new workflow
- track changes in model_log

## Testing
- `ruff check hourly_analysis.py pipeline.py tests/test_hourly_forecast.py`
- `PYTHONPATH=. pytest tests/test_hourly_forecast.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6840bd152420832e8bdafd09c8c0d0c1